### PR TITLE
Workflows

### DIFF
--- a/backend/internal/handlers/auth.go
+++ b/backend/internal/handlers/auth.go
@@ -2,59 +2,45 @@ package handlers
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
-	"time"
 
 	"github.com/pseudo/vibe-seeker/backend/internal/auth"
 	"github.com/pseudo/vibe-seeker/backend/internal/configuration"
 	"github.com/pseudo/vibe-seeker/backend/internal/middleware"
 	"github.com/pseudo/vibe-seeker/backend/internal/observability"
+	"github.com/pseudo/vibe-seeker/backend/internal/service"
 	"github.com/pseudo/vibe-seeker/backend/internal/spotify"
 )
 
-// UserUpserter persists user data on login.
-type UserUpserter interface {
-	UpsertUser(ctx context.Context, id, displayName, accessToken, refreshToken string, tokenExpiry int) error
+// Authenticator handles the business logic of user authentication.
+type Authenticator interface {
+	LoginWithSpotify(ctx context.Context, code string) (*service.LoginResult, error)
+	LoginAnonymous(ctx context.Context, turnstileToken string) (*service.LoginResult, error)
 }
 
-// TurnstileVerifyURL is the Cloudflare Turnstile verification endpoint.
-// Exported so tests can override it with a mock server.
-var TurnstileVerifyURL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
-
-// errTurnstileRejected indicates Cloudflare explicitly rejected the token.
-// Other verifyTurnstile errors (network, decode, misconfiguration) are server-side.
-var errTurnstileRejected = errors.New("turnstile token rejected")
-
+// AuthHandler handles HTTP authentication endpoints.
 type AuthHandler struct {
-	Spotify            *spotify.Client
-	Users              UserUpserter
-	JWTSecret          string
-	FrontendURL        string
-	TurnstileSecretKey string
-	SecureCookie       bool
+	auth         Authenticator
+	spotify      *spotify.Client // only for AuthorizeURL in Login
+	frontendURL  string
+	secureCookie bool
 }
 
-func NewAuthHandler(spotify *spotify.Client, users UserUpserter, jwtSecret, frontendURL, turnstileSecretKey string, secureCookie bool) (*AuthHandler, error) {
-	if spotify == nil {
+func NewAuthHandler(sp *spotify.Client, authSvc Authenticator, frontendURL string, secureCookie bool) (*AuthHandler, error) {
+	if sp == nil {
 		return nil, errors.New("auth: nil spotify client")
 	}
-	if users == nil {
-		return nil, errors.New("auth: nil user store")
+	if authSvc == nil {
+		return nil, errors.New("auth: nil auth service")
 	}
 	return &AuthHandler{
-		Spotify:            spotify,
-		Users:              users,
-		JWTSecret:          jwtSecret,
-		FrontendURL:        frontendURL,
-		TurnstileSecretKey: turnstileSecretKey,
-		SecureCookie:       secureCookie,
+		auth:         authSvc,
+		spotify:      sp,
+		frontendURL:  frontendURL,
+		secureCookie: secureCookie,
 	}, nil
 }
 
@@ -75,7 +61,7 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		SameSite: http.SameSiteLaxMode,
 	})
 
-	http.Redirect(w, r, h.Spotify.AuthorizeURL(state), http.StatusFound)
+	http.Redirect(w, r, h.spotify.AuthorizeURL(state), http.StatusFound)
 }
 
 func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
@@ -95,7 +81,7 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 
 	if errParam := r.URL.Query().Get("error"); errParam != "" {
 		observability.Logger(r.Context()).Error("spotify auth error", "error", errParam)
-		http.Redirect(w, r, h.FrontendURL+"/?error="+url.QueryEscape(errParam), http.StatusFound)
+		http.Redirect(w, r, h.frontendURL+"/?error="+url.QueryEscape(errParam), http.StatusFound)
 		return
 	}
 
@@ -105,45 +91,15 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tokenResp, err := h.Spotify.ExchangeCode(r.Context(), code)
+	result, err := h.auth.LoginWithSpotify(r.Context(), code)
 	if err != nil {
-		httpError(w, r, http.StatusInternalServerError, "failed to exchange code",
-			"failed to exchange code", "error", err)
+		httpError(w, r, http.StatusInternalServerError, "failed to complete login",
+			"spotify login failed", "error", err)
 		return
 	}
 
-	profile, err := h.Spotify.FetchProfile(r.Context(), tokenResp.AccessToken)
-	if err != nil {
-		httpError(w, r, http.StatusInternalServerError, "failed to fetch profile",
-			"failed to fetch profile", "error", err)
-		return
-	}
-
-	tokenExpiry := int(time.Now().Unix()) + tokenResp.ExpiresIn
-	if err := h.Users.UpsertUser(r.Context(), profile.ID, profile.DisplayName, tokenResp.AccessToken, tokenResp.RefreshToken, tokenExpiry); err != nil {
-		httpError(w, r, http.StatusInternalServerError, "internal error",
-			"failed to persist user", "error", err)
-		return
-	}
-
-	jwt, err := auth.CreateToken(h.JWTSecret, profile.ID, profile.DisplayName)
-	if err != nil {
-		httpError(w, r, http.StatusInternalServerError, "internal error",
-			"failed to create token", "error", err)
-		return
-	}
-
-	http.SetCookie(w, &http.Cookie{
-		Name:     "session",
-		Value:    jwt,
-		Path:     "/api",
-		MaxAge:   configuration.SessionCookieMaxAge,
-		HttpOnly: true,
-		Secure:   h.SecureCookie,
-		SameSite: http.SameSiteLaxMode,
-	})
-
-	http.Redirect(w, r, h.FrontendURL+"/callback", http.StatusFound)
+	h.setSessionCookie(w, result.JWT)
+	http.Redirect(w, r, h.frontendURL+"/callback", http.StatusFound)
 }
 
 // Me returns the authenticated user's identity from the JWT claims.
@@ -162,7 +118,7 @@ func (h *AuthHandler) Me(w http.ResponseWriter, r *http.Request) {
 }
 
 // AnonymousLogin validates a Cloudflare Turnstile token and issues a
-// session cookie with an anonymous JWT. No user row is created.
+// session cookie with an anonymous JWT.
 func (h *AuthHandler) AnonymousLogin(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		TurnstileToken string `json:"turnstile_token"`
@@ -172,8 +128,9 @@ func (h *AuthHandler) AnonymousLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.verifyTurnstile(r.Context(), body.TurnstileToken); err != nil {
-		if errors.Is(err, errTurnstileRejected) {
+	result, err := h.auth.LoginAnonymous(r.Context(), body.TurnstileToken)
+	if err != nil {
+		if errors.Is(err, service.ErrTurnstileRejected) {
 			httpError(w, r, http.StatusForbidden, "captcha verification failed",
 				"turnstile token rejected", "error", err)
 		} else {
@@ -183,80 +140,13 @@ func (h *AuthHandler) AnonymousLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	anonID, err := generateAnonymousID()
-	if err != nil {
-		httpError(w, r, http.StatusInternalServerError, "internal error",
-			"failed to generate anonymous id", "error", err)
-		return
-	}
-
-	jwt, err := auth.CreateToken(h.JWTSecret, anonID, "Explorer")
-	if err != nil {
-		httpError(w, r, http.StatusInternalServerError, "internal error",
-			"failed to create anonymous token", "error", err)
-		return
-	}
-
-	http.SetCookie(w, &http.Cookie{
-		Name:     "session",
-		Value:    jwt,
-		Path:     "/api",
-		MaxAge:   configuration.SessionCookieMaxAge,
-		HttpOnly: true,
-		Secure:   h.SecureCookie,
-		SameSite: http.SameSiteLaxMode,
-	})
+	h.setSessionCookie(w, result.JWT)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]string{
-		"spotify_id":   anonID,
-		"display_name": "Explorer",
+		"spotify_id":   result.UserID,
+		"display_name": result.DisplayName,
 	})
-}
-
-// verifyTurnstile validates a Turnstile token with the Cloudflare API.
-func (h *AuthHandler) verifyTurnstile(ctx context.Context, token string) error {
-	if h.TurnstileSecretKey == "" {
-		return fmt.Errorf("turnstile secret key not configured")
-	}
-
-	form := url.Values{
-		"secret":   {h.TurnstileSecretKey},
-		"response": {token},
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, TurnstileVerifyURL, strings.NewReader(form.Encode()))
-	if err != nil {
-		return fmt.Errorf("creating turnstile request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("calling turnstile API: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var result struct {
-		Success bool `json:"success"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return fmt.Errorf("decoding turnstile response: %w", err)
-	}
-
-	if !result.Success {
-		return errTurnstileRejected
-	}
-	return nil
-}
-
-// generateAnonymousID creates a random anonymous user identifier.
-func generateAnonymousID() (string, error) {
-	b := make([]byte, 16)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
-	}
-	return "anon-" + hex.EncodeToString(b), nil
 }
 
 // Logout clears the session cookie.
@@ -267,9 +157,21 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 		Path:     "/api",
 		MaxAge:   -1,
 		HttpOnly: true,
-		Secure:   h.SecureCookie,
+		Secure:   h.secureCookie,
 		SameSite: http.SameSiteLaxMode,
 	})
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *AuthHandler) setSessionCookie(w http.ResponseWriter, jwt string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     "session",
+		Value:    jwt,
+		Path:     "/api",
+		MaxAge:   configuration.SessionCookieMaxAge,
+		HttpOnly: true,
+		Secure:   h.secureCookie,
+		SameSite: http.SameSiteLaxMode,
+	})
 }

--- a/backend/internal/handlers/auth_test.go
+++ b/backend/internal/handlers/auth_test.go
@@ -5,38 +5,60 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 	"testing"
 
 	"github.com/pseudo/vibe-seeker/backend/internal/auth"
 	"github.com/pseudo/vibe-seeker/backend/internal/middleware"
+	"github.com/pseudo/vibe-seeker/backend/internal/service"
 	"github.com/pseudo/vibe-seeker/backend/internal/spotify"
 )
 
-// mockUserStore implements UserUpserter for tests.
-type mockUserStore struct {
-	called      bool
-	lastID      string
-	lastDisplay string
-	err         error
+// mockAuthService implements Authenticator for tests.
+type mockAuthService struct {
+	loginResult *service.LoginResult
+	loginErr    error
+	anonResult  *service.LoginResult
+	anonErr     error
 }
 
-func (m *mockUserStore) UpsertUser(_ context.Context, id, displayName, _, _ string, _ int) error {
-	m.called = true
-	m.lastID = id
-	m.lastDisplay = displayName
-	return m.err
+func (m *mockAuthService) LoginWithSpotify(_ context.Context, _ string) (*service.LoginResult, error) {
+	return m.loginResult, m.loginErr
+}
+
+func (m *mockAuthService) LoginAnonymous(_ context.Context, _ string) (*service.LoginResult, error) {
+	return m.anonResult, m.anonErr
 }
 
 func newTestHandler(t *testing.T) *AuthHandler {
 	t.Helper()
-	spotify := spotify.NewClient("client-id", "client-secret", "http://localhost:8080/api/auth/callback")
-	h, err := NewAuthHandler(spotify, &mockUserStore{}, "jwt-secret", "http://localhost:5173", "test-turnstile-secret", false)
+	sp := spotify.NewClient("client-id", "client-secret", "http://localhost:8080/api/auth/callback")
+	jwt, _ := auth.CreateToken("jwt-secret", "spotify123", "Test User")
+	h, err := NewAuthHandler(sp, &mockAuthService{
+		loginResult: &service.LoginResult{JWT: jwt, UserID: "spotify123", DisplayName: "Test User"},
+		anonResult:  &service.LoginResult{JWT: jwt, UserID: "anon-abc123", DisplayName: "Explorer"},
+	}, "http://localhost:5173", false)
 	if err != nil {
 		t.Fatalf("NewAuthHandler: %v", err)
 	}
 	return h
+}
+
+func newTestHandlerWithMockSpotify(t *testing.T) (*AuthHandler, *mockAuthService) {
+	t.Helper()
+
+	sp := spotify.NewClient("client-id", "client-secret", "http://localhost:5173/api/auth/callback")
+
+	jwt, _ := auth.CreateToken("jwt-secret", "spotify123", "Test User")
+	authSvc := &mockAuthService{
+		loginResult: &service.LoginResult{JWT: jwt, UserID: "spotify123", DisplayName: "Test User"},
+	}
+
+	h, err := NewAuthHandler(sp, authSvc, "http://localhost:5173", false)
+	if err != nil {
+		t.Fatalf("NewAuthHandler: %v", err)
+	}
+	return h, authSvc
 }
 
 func TestLogin_RedirectsToSpotify(t *testing.T) {
@@ -54,17 +76,9 @@ func TestLogin_RedirectsToSpotify(t *testing.T) {
 		t.Fatalf("expected status 302, got %d", res.StatusCode)
 	}
 
-	location, err := url.Parse(res.Header.Get("Location"))
-	if err != nil {
-		t.Fatalf("failed to parse Location header: %v", err)
-	}
-
-	if location.Host != "accounts.spotify.com" {
-		t.Errorf("expected redirect to accounts.spotify.com, got %s", location.Host)
-	}
-
-	if location.Query().Get("state") == "" {
-		t.Error("expected non-empty state parameter")
+	location := res.Header.Get("Location")
+	if !strings.Contains(location, "accounts.spotify.com") {
+		t.Errorf("expected redirect to accounts.spotify.com, got %s", location)
 	}
 }
 
@@ -206,7 +220,6 @@ func TestMe_ReturnsUserInfo(t *testing.T) {
 		t.Fatalf("CreateToken failed: %v", err)
 	}
 
-	// Wrap the Me handler with auth middleware.
 	handler := middleware.RequireAuth("jwt-secret")(http.HandlerFunc(h.Me))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/me", nil)
@@ -220,10 +233,10 @@ func TestMe_ReturnsUserInfo(t *testing.T) {
 	}
 
 	body := rec.Body.String()
-	if !contains(body, "spotify123") {
+	if !strings.Contains(body, "spotify123") {
 		t.Errorf("response should contain spotify_id, got: %s", body)
 	}
-	if !contains(body, "Test User") {
+	if !strings.Contains(body, "Test User") {
 		t.Errorf("response should contain display_name, got: %s", body)
 	}
 }
@@ -271,44 +284,8 @@ func TestLogout_ClearsSessionCookie(t *testing.T) {
 	}
 }
 
-// newTestHandlerWithMockSpotify creates an AuthHandler backed by a mock Spotify API
-// that returns a valid token exchange and profile response.
-func newTestHandlerWithMockSpotify(t *testing.T) (*AuthHandler, *mockUserStore, *httptest.Server) {
-	t.Helper()
-
-	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/api/token":
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
-				"access_token":  "mock-access-token",
-				"refresh_token": "mock-refresh-token",
-				"expires_in":    3600,
-			})
-		case "/v1/me":
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]string{"id": "spotify123", "display_name": "Test User"})
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-
-	spotify := spotify.NewClient("client-id", "client-secret", "http://localhost:5173/api/auth/callback")
-	spotify.TokenURL = mock.URL + "/api/token"
-	spotify.MeURL = mock.URL + "/v1/me"
-	spotify.HTTPClient = mock.Client()
-
-	users := &mockUserStore{}
-	h, err := NewAuthHandler(spotify, users, "jwt-secret", "http://localhost:5173", "test-turnstile-secret", false)
-	if err != nil {
-		t.Fatalf("NewAuthHandler: %v", err)
-	}
-	return h, users, mock
-}
-
 func TestCallback_Success_SetsSessionCookie(t *testing.T) {
-	h, _, mock := newTestHandlerWithMockSpotify(t)
-	defer mock.Close()
+	h, _ := newTestHandlerWithMockSpotify(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?state=valid&code=test-code", nil)
 	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: "valid"})
@@ -355,8 +332,7 @@ func TestCallback_Success_SetsSessionCookie(t *testing.T) {
 }
 
 func TestCallback_Success_CookieProperties(t *testing.T) {
-	h, _, mock := newTestHandlerWithMockSpotify(t)
-	defer mock.Close()
+	h, _ := newTestHandlerWithMockSpotify(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?state=valid&code=test-code", nil)
 	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: "valid"})
@@ -401,30 +377,8 @@ func TestCallback_Success_CookieProperties(t *testing.T) {
 	}
 }
 
-func TestCallback_Success_UpsertsUser(t *testing.T) {
-	h, users, mock := newTestHandlerWithMockSpotify(t)
-	defer mock.Close()
-
-	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?state=valid&code=test-code", nil)
-	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: "valid"})
-	rec := httptest.NewRecorder()
-
-	h.Callback(rec, req)
-
-	if !users.called {
-		t.Fatal("expected UpsertUser to be called")
-	}
-	if users.lastID != "spotify123" {
-		t.Errorf("UpsertUser id = %q, want %q", users.lastID, "spotify123")
-	}
-	if users.lastDisplay != "Test User" {
-		t.Errorf("UpsertUser displayName = %q, want %q", users.lastDisplay, "Test User")
-	}
-}
-
 func TestCallback_Success_RedirectsToFrontend(t *testing.T) {
-	h, _, mock := newTestHandlerWithMockSpotify(t)
-	defer mock.Close()
+	h, _ := newTestHandlerWithMockSpotify(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?state=valid&code=test-code", nil)
 	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: "valid"})
@@ -441,16 +395,11 @@ func TestCallback_Success_RedirectsToFrontend(t *testing.T) {
 	}
 }
 
-func TestCallback_ExchangeCodeFailure(t *testing.T) {
-	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusBadRequest)
-	}))
-	defer mock.Close()
-
-	spotify := spotify.NewClient("client-id", "client-secret", "http://localhost:5173/api/auth/callback")
-	spotify.TokenURL = mock.URL + "/api/token"
-	spotify.HTTPClient = mock.Client()
-	h, err := NewAuthHandler(spotify, &mockUserStore{}, "jwt-secret", "http://localhost:5173", "test-turnstile-secret", false)
+func TestCallback_ServiceFailure(t *testing.T) {
+	sp := spotify.NewClient("client-id", "client-secret", "http://localhost:5173/api/auth/callback")
+	h, err := NewAuthHandler(sp, &mockAuthService{
+		loginErr: context.DeadlineExceeded,
+	}, "http://localhost:5173", false)
 	if err != nil {
 		t.Fatalf("NewAuthHandler: %v", err)
 	}
@@ -534,22 +483,24 @@ func TestMe_ResponseFormat(t *testing.T) {
 
 // --- Anonymous login tests ---
 
-func newTurnstileMock(t *testing.T, success bool) *httptest.Server {
+func newAnonymousTestHandler(t *testing.T, anonResult *service.LoginResult, anonErr error) *AuthHandler {
 	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]bool{"success": success})
-	}))
+	sp := spotify.NewClient("client-id", "client-secret", "http://localhost:8080/api/auth/callback")
+	h, err := NewAuthHandler(sp, &mockAuthService{
+		anonResult: anonResult,
+		anonErr:    anonErr,
+	}, "http://localhost:5173", false)
+	if err != nil {
+		t.Fatalf("NewAuthHandler: %v", err)
+	}
+	return h
 }
 
 func TestAnonymousLogin_Success(t *testing.T) {
-	mock := newTurnstileMock(t, true)
-	defer mock.Close()
-	original := TurnstileVerifyURL
-	TurnstileVerifyURL = mock.URL
-	defer func() { TurnstileVerifyURL = original }()
-
-	h := newTestHandler(t)
+	jwt, _ := auth.CreateToken("jwt-secret", "anon-abc123", "Explorer")
+	h := newAnonymousTestHandler(t, &service.LoginResult{
+		JWT: jwt, UserID: "anon-abc123", DisplayName: "Explorer",
+	}, nil)
 
 	body := strings.NewReader(`{"turnstile_token":"test-token"}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/anonymous", body)
@@ -581,8 +532,8 @@ func TestAnonymousLogin_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("session cookie is not a valid JWT: %v", err)
 	}
-	if !strings.HasPrefix(claims.SpotifyID, "anon-") {
-		t.Errorf("expected anonymous SpotifyID prefix, got %q", claims.SpotifyID)
+	if claims.SpotifyID != "anon-abc123" {
+		t.Errorf("expected anonymous SpotifyID, got %q", claims.SpotifyID)
 	}
 	if claims.DisplayName != "Explorer" {
 		t.Errorf("DisplayName = %q, want %q", claims.DisplayName, "Explorer")
@@ -599,13 +550,7 @@ func TestAnonymousLogin_Success(t *testing.T) {
 }
 
 func TestAnonymousLogin_TurnstileRejected(t *testing.T) {
-	mock := newTurnstileMock(t, false)
-	defer mock.Close()
-	original := TurnstileVerifyURL
-	TurnstileVerifyURL = mock.URL
-	defer func() { TurnstileVerifyURL = original }()
-
-	h := newTestHandler(t)
+	h := newAnonymousTestHandler(t, nil, service.ErrTurnstileRejected)
 
 	body := strings.NewReader(`{"turnstile_token":"bad-token"}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/anonymous", body)
@@ -633,13 +578,10 @@ func TestAnonymousLogin_MissingToken(t *testing.T) {
 }
 
 func TestAnonymousLogin_CookieProperties(t *testing.T) {
-	mock := newTurnstileMock(t, true)
-	defer mock.Close()
-	original := TurnstileVerifyURL
-	TurnstileVerifyURL = mock.URL
-	defer func() { TurnstileVerifyURL = original }()
-
-	h := newTestHandler(t)
+	jwt, _ := auth.CreateToken("jwt-secret", "anon-abc123", "Explorer")
+	h := newAnonymousTestHandler(t, &service.LoginResult{
+		JWT: jwt, UserID: "anon-abc123", DisplayName: "Explorer",
+	}, nil)
 
 	body := strings.NewReader(`{"turnstile_token":"test-token"}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/anonymous", body)
@@ -672,13 +614,10 @@ func TestAnonymousLogin_CookieProperties(t *testing.T) {
 }
 
 func TestAnonymousLogin_JWTPassesRequireAuth(t *testing.T) {
-	mock := newTurnstileMock(t, true)
-	defer mock.Close()
-	original := TurnstileVerifyURL
-	TurnstileVerifyURL = mock.URL
-	defer func() { TurnstileVerifyURL = original }()
-
-	h := newTestHandler(t)
+	jwt, _ := auth.CreateToken("jwt-secret", "anon-abc123", "Explorer")
+	h := newAnonymousTestHandler(t, &service.LoginResult{
+		JWT: jwt, UserID: "anon-abc123", DisplayName: "Explorer",
+	}, nil)
 
 	// Get an anonymous session cookie.
 	body := strings.NewReader(`{"turnstile_token":"test-token"}`)
@@ -713,20 +652,7 @@ func TestAnonymousLogin_JWTPassesRequireAuth(t *testing.T) {
 	if err := json.NewDecoder(meRec.Body).Decode(&meBody); err != nil {
 		t.Fatalf("failed to decode /me response: %v", err)
 	}
-	if !strings.HasPrefix(meBody["spotify_id"], "anon-") {
+	if meBody["spotify_id"] != "anon-abc123" {
 		t.Errorf("expected anonymous spotify_id, got %q", meBody["spotify_id"])
 	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && searchString(s, substr)
-}
-
-func searchString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/backend/internal/handlers/explore.go
+++ b/backend/internal/handlers/explore.go
@@ -10,21 +10,21 @@ import (
 	"github.com/pseudo/vibe-seeker/backend/internal/store"
 )
 
-// TagReader provides read access to global tag data for the explore graph.
-type TagReader interface {
-	GetTopTags(ctx context.Context, limit int) ([]store.TagPrevalence, error)
-	GetRelatedTags(ctx context.Context, tag string, limit int) ([]store.TagRelation, error)
+// VibeExplorer provides tag exploration operations.
+type VibeExplorer interface {
+	GetTopVibes(ctx context.Context, limit int) ([]store.TagPrevalence, error)
+	GetRelatedVibes(ctx context.Context, tag string, limit int) ([]store.TagRelation, error)
 }
 
 type ExploreHandler struct {
-	Tags TagReader
+	explore VibeExplorer
 }
 
-func NewExploreHandler(tags TagReader) (*ExploreHandler, error) {
-	if tags == nil {
-		return nil, errors.New("explore: nil tag reader")
+func NewExploreHandler(explore VibeExplorer) (*ExploreHandler, error) {
+	if explore == nil {
+		return nil, errors.New("explore: nil explore service")
 	}
-	return &ExploreHandler{Tags: tags}, nil
+	return &ExploreHandler{explore: explore}, nil
 }
 
 // GetTopVibes returns the most prevalent vibes across all cached artist data.
@@ -37,7 +37,7 @@ func (h *ExploreHandler) GetTopVibes(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	tags, err := h.Tags.GetTopTags(r.Context(), limit)
+	tags, err := h.explore.GetTopVibes(r.Context(), limit)
 	if err != nil {
 		httpError(w, r, http.StatusInternalServerError, "failed to fetch vibes",
 			"failed to query top tags", "error", err)
@@ -66,7 +66,7 @@ func (h *ExploreHandler) GetRelatedVibes(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	related, err := h.Tags.GetRelatedTags(r.Context(), tag, limit)
+	related, err := h.explore.GetRelatedVibes(r.Context(), tag, limit)
 	if err != nil {
 		httpError(w, r, http.StatusInternalServerError, "failed to fetch related vibes",
 			"failed to query related tags", "error", err, "tag", tag)

--- a/backend/internal/handlers/explore_test.go
+++ b/backend/internal/handlers/explore_test.go
@@ -10,29 +10,29 @@ import (
 	"github.com/pseudo/vibe-seeker/backend/internal/store"
 )
 
-type mockTagReader struct {
-	topTags     []store.TagPrevalence
-	relatedTags []store.TagRelation
+type mockExploreService struct {
+	topVibes    []store.TagPrevalence
 	topErr      error
+	relatedTags []store.TagRelation
 	relatedErr  error
 	lastTag     string
 	lastLimit   int
 }
 
-func (m *mockTagReader) GetTopTags(_ context.Context, limit int) ([]store.TagPrevalence, error) {
+func (m *mockExploreService) GetTopVibes(_ context.Context, limit int) ([]store.TagPrevalence, error) {
 	m.lastLimit = limit
-	return m.topTags, m.topErr
+	return m.topVibes, m.topErr
 }
 
-func (m *mockTagReader) GetRelatedTags(_ context.Context, tag string, limit int) ([]store.TagRelation, error) {
+func (m *mockExploreService) GetRelatedVibes(_ context.Context, tag string, limit int) ([]store.TagRelation, error) {
 	m.lastTag = tag
 	m.lastLimit = limit
 	return m.relatedTags, m.relatedErr
 }
 
 func TestGetTopVibes_DefaultLimit(t *testing.T) {
-	mock := &mockTagReader{
-		topTags: []store.TagPrevalence{
+	mock := &mockExploreService{
+		topVibes: []store.TagPrevalence{
 			{Tag: "rock", Prevalence: 1.0},
 			{Tag: "indie", Prevalence: 0.85},
 		},
@@ -70,7 +70,7 @@ func TestGetTopVibes_DefaultLimit(t *testing.T) {
 }
 
 func TestGetTopVibes_CustomLimit(t *testing.T) {
-	mock := &mockTagReader{topTags: []store.TagPrevalence{}}
+	mock := &mockExploreService{topVibes: []store.TagPrevalence{}}
 	h, _ := NewExploreHandler(mock)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/vibes/top?limit=25", nil)
@@ -84,7 +84,7 @@ func TestGetTopVibes_CustomLimit(t *testing.T) {
 }
 
 func TestGetTopVibes_LimitCapped(t *testing.T) {
-	mock := &mockTagReader{topTags: []store.TagPrevalence{}}
+	mock := &mockExploreService{topVibes: []store.TagPrevalence{}}
 	h, _ := NewExploreHandler(mock)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/vibes/top?limit=999", nil)
@@ -99,7 +99,7 @@ func TestGetTopVibes_LimitCapped(t *testing.T) {
 }
 
 func TestGetRelatedVibes_Success(t *testing.T) {
-	mock := &mockTagReader{
+	mock := &mockExploreService{
 		relatedTags: []store.TagRelation{
 			{Tag: "indie", Strength: 1.0},
 			{Tag: "alternative", Strength: 0.75},
@@ -123,8 +123,8 @@ func TestGetRelatedVibes_Success(t *testing.T) {
 	}
 
 	var body struct {
-		Tag     string               `json:"tag"`
-		Related []store.TagRelation  `json:"related"`
+		Tag     string              `json:"tag"`
+		Related []store.TagRelation `json:"related"`
 	}
 	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
@@ -138,7 +138,7 @@ func TestGetRelatedVibes_Success(t *testing.T) {
 }
 
 func TestGetRelatedVibes_MissingTag(t *testing.T) {
-	h, _ := NewExploreHandler(&mockTagReader{})
+	h, _ := NewExploreHandler(&mockExploreService{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/vibes/related", nil)
 	rec := httptest.NewRecorder()
@@ -150,9 +150,9 @@ func TestGetRelatedVibes_MissingTag(t *testing.T) {
 	}
 }
 
-func TestNewExploreHandler_NilTagReader(t *testing.T) {
+func TestNewExploreHandler_NilService(t *testing.T) {
 	_, err := NewExploreHandler(nil)
 	if err == nil {
-		t.Error("expected error for nil tag reader")
+		t.Error("expected error for nil explore service")
 	}
 }

--- a/backend/internal/handlers/venues.go
+++ b/backend/internal/handlers/venues.go
@@ -4,95 +4,33 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log/slog"
 	"net/http"
-	"strings"
 	"time"
 
-	"github.com/pseudo/vibe-seeker/backend/internal/configuration"
-	"github.com/pseudo/vibe-seeker/backend/internal/lastfm"
 	"github.com/pseudo/vibe-seeker/backend/internal/middleware"
-	"github.com/pseudo/vibe-seeker/backend/internal/observability"
-	"github.com/pseudo/vibe-seeker/backend/internal/ratelimit"
-	"github.com/pseudo/vibe-seeker/backend/internal/store"
-	"github.com/pseudo/vibe-seeker/backend/internal/ticketmaster"
-	"github.com/pseudo/vibe-seeker/backend/internal/vibes"
+	"github.com/pseudo/vibe-seeker/backend/internal/service"
 )
 
-// nycSearchTiles covers the NYC metro area with overlapping 3-mile-radius
-// circles, each staying under Ticketmaster's 1,000-result pagination limit.
-// Results are deduplicated by venue ID after fetching.
-var nycSearchTiles = []ticketmaster.VenueSearchOptions{
-	{GeoPoint: "40.7128,-74.0060", Radius: "3"},  // Lower/Midtown Manhattan
-	{GeoPoint: "40.8100,-73.9500", Radius: "3"},  // Upper Manhattan / Harlem
-	{GeoPoint: "40.6782,-73.9442", Radius: "3"},  // Brooklyn
-	{GeoPoint: "40.7282,-73.7949", Radius: "3"},  // Queens
-	{GeoPoint: "40.8448,-73.8648", Radius: "3"},  // Bronx
-	{GeoPoint: "40.7178,-74.0431", Radius: "3"},  // Hoboken / Jersey City
+// VenueManager provides venue sync, vibe computation, and listing operations.
+type VenueManager interface {
+	SyncVenues(ctx context.Context) (*service.VenueSyncResult, error)
+	SyncVenueVibes(ctx context.Context) (int, error)
+	GetVenues(ctx context.Context) ([]service.VenueWithDetails, error)
 }
 
-// VenueWriter persists venue, show, and artist data.
-type VenueWriter interface {
-	UpsertVenues(ctx context.Context, venues []store.Venue) error
-	UpsertShows(ctx context.Context, shows []store.Show) error
-	UpsertArtists(ctx context.Context, artists []store.Artist) error
-	UpsertShowArtists(ctx context.Context, links []store.ShowArtist) error
-	UpsertShowClassifications(ctx context.Context, classifications []store.ShowClassification) error
-	GetVenueFetchedAt(ctx context.Context, dataSource string) (*time.Time, error)
-}
-
-// VenueReader retrieves venue data.
-type VenueReader interface {
-	GetVenues(ctx context.Context) ([]store.Venue, error)
-	GetShowsForVenues(ctx context.Context, venueIDs []string) (map[string][]store.ShowSummary, error)
-	GetAllVenueArtists(ctx context.Context, venueIDs []string) (map[string][]store.VenueArtist, error)
-	GetAllVenueVibes(ctx context.Context, venueIDs []string) (map[string]map[string]float32, error)
-}
-
-// VenueVibeWriter persists venue vibe profiles.
-type VenueVibeWriter interface {
-	UpsertVenueVibes(ctx context.Context, venueID string, vibeWeights map[string]float32) error
-}
-
-// VenueHandler orchestrates venue and event ingestion from Ticketmaster.
+// VenueHandler handles HTTP venue endpoints.
 type VenueHandler struct {
-	Ticketmaster *ticketmaster.Client
-	LastFM       *lastfm.Client
-	Venues       VenueWriter
-	VenueReader  VenueReader
-	VenueVibes   VenueVibeWriter
-	TagCache     TagCache
+	venues VenueManager
 }
 
-func NewVenueHandler(tm *ticketmaster.Client, lfm *lastfm.Client, venues interface {
-	VenueWriter
-	VenueReader
-	VenueVibeWriter
-}, tagCache TagCache) (*VenueHandler, error) {
-	if tm == nil {
-		return nil, errors.New("venues: nil ticketmaster client")
-	}
-	if lfm == nil {
-		return nil, errors.New("venues: nil lastfm client")
-	}
+func NewVenueHandler(venues VenueManager) (*VenueHandler, error) {
 	if venues == nil {
-		return nil, errors.New("venues: nil venue store")
+		return nil, errors.New("venues: nil venue service")
 	}
-	if tagCache == nil {
-		return nil, errors.New("venues: nil tag cache")
-	}
-	return &VenueHandler{
-		Ticketmaster: tm,
-		LastFM:       lfm,
-		Venues:       venues,
-		VenueReader:  venues,
-		VenueVibes:   venues,
-		TagCache:     tagCache,
-	}, nil
+	return &VenueHandler{venues: venues}, nil
 }
 
-// SyncVenues fetches NYC venues and upcoming events from Ticketmaster and
-// persists them to the database.
+// SyncVenues triggers a venue and event sync from Ticketmaster.
 func (h *VenueHandler) SyncVenues(w http.ResponseWriter, r *http.Request) {
 	claims := middleware.ClaimsFromContext(r.Context())
 	if claims == nil {
@@ -100,240 +38,34 @@ func (h *VenueHandler) SyncVenues(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := r.Context()
-	log := observability.Logger(ctx)
-
-	// TTL check: skip if data is fresh.
-	lastFetched, err := h.Venues.GetVenueFetchedAt(ctx, configuration.DataSourceTicketmaster)
+	result, err := h.venues.SyncVenues(r.Context())
 	if err != nil {
-		log.Error("failed to check venue TTL, proceeding with sync", "error", err)
+		httpError(w, r, http.StatusInternalServerError, "internal error",
+			"venue sync failed", "error", err)
+		return
 	}
-	if err == nil && lastFetched != nil && time.Since(*lastFetched) < configuration.VenueCacheTTL {
+
+	if result.Skipped {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"synced":       false,
 			"reason":       "data is fresh",
-			"last_fetched": lastFetched.Format(time.RFC3339),
+			"last_fetched": result.LastFetched.Format(time.RFC3339),
 		})
 		return
 	}
-
-	syncCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), configuration.VenueSyncTimeout)
-	defer cancel()
-
-	limiter := ratelimit.NewLimiter(configuration.TicketmasterRateLimit)
-	defer limiter.Stop()
-
-	// 1. Fetch venues from tiled search regions, deduplicating by TM ID.
-	seen := make(map[string]bool)
-	var tmVenues []ticketmaster.Venue
-	for _, tile := range nycSearchTiles {
-		if syncCtx.Err() != nil {
-			log.Error("venue fetch timed out", "fetched", len(tmVenues))
-			break
-		}
-		if err := limiter.Wait(syncCtx); err != nil {
-			log.Error("rate limiter wait failed", "error", err)
-			break
-		}
-		tileVenues, err := h.Ticketmaster.SearchVenues(syncCtx, tile)
-		if err != nil {
-			log.Error("failed to fetch ticketmaster venues", "tile", tile.GeoPoint, "error", err)
-			continue
-		}
-		for _, v := range tileVenues {
-			if !seen[v.ID] {
-				seen[v.ID] = true
-				tmVenues = append(tmVenues, v)
-			}
-		}
-		log.Info("tile fetched", "center", tile.GeoPoint, "raw", len(tileVenues), "unique_total", len(tmVenues))
-	}
-
-	storeVenues := mapVenues(tmVenues)
-	dbCtx := context.WithoutCancel(ctx)
-	if err := h.Venues.UpsertVenues(dbCtx, storeVenues); err != nil {
-		httpError(w, r, http.StatusInternalServerError, "internal error",
-			"failed to persist venues", "error", err)
-		return
-	}
-	log.Info("venues synced", "count", len(storeVenues))
-
-	// 2. Fetch events per venue with adaptive rate limiting.
-	// On 429: requeue the venue and increase delay by 1s.
-	// On 200: decrease delay by 1s (floor at configuration.TicketmasterRateLimit).
-	now := time.Now().UTC().Format("2006-01-02T15:04:05Z")
-
-	var shows []store.Show
-	var artists []store.Artist
-	var showArtists []store.ShowArtist
-	var classifications []store.ShowClassification
-	seenArtists := make(map[string]bool)
-
-	queue := make([]store.Venue, len(storeVenues))
-	copy(queue, storeVenues)
-	delay := configuration.TicketmasterRateLimit
-	processed := 0
-
-	for len(queue) > 0 {
-		if syncCtx.Err() != nil {
-			log.Error("event fetch timed out", "processed", processed, "remaining", len(queue))
-			break
-		}
-
-		sv := queue[0]
-		queue = queue[1:]
-
-		log.Info("fetching events", "venue", sv.Name, "processed", processed, "remaining", len(queue), "delay", delay)
-		select {
-		case <-syncCtx.Done():
-			log.Error("event fetch timed out during delay", "processed", processed, "remaining", len(queue))
-			queue = nil // break outer loop
-			continue
-		case <-time.After(delay):
-		}
-		tmEvents, err := h.Ticketmaster.SearchEvents(syncCtx, ticketmaster.EventSearchOptions{
-			VenueID:       sv.TMID,
-			StartDateTime: now,
-		})
-		if errors.Is(err, ticketmaster.ErrRateLimited) {
-			queue = append(queue, sv) // requeue
-			delay += 1 * time.Second
-			log.Info("rate limited, backing off", "delay", delay, "remaining", len(queue))
-			continue
-		}
-		if err != nil {
-			log.Error("failed to fetch events for venue", "venue", sv.Name, "error", err)
-			continue
-		}
-
-		// Successful request — reduce delay toward floor.
-		if delay > configuration.TicketmasterRateLimit {
-			delay -= 1 * time.Second
-			if delay < configuration.TicketmasterRateLimit {
-				delay = configuration.TicketmasterRateLimit
-			}
-		}
-		processed++
-		log.Info("events fetched", "venue", sv.Name, "events", len(tmEvents), "shows_total", len(shows)+len(tmEvents))
-
-		for _, ev := range tmEvents {
-			showID := configuration.IDPrefixTicketmaster + ev.ID
-			showDate, err := time.Parse(time.RFC3339, ev.Dates.Start.DateTime)
-			if err != nil {
-				// Try localDate as fallback.
-				showDate, err = time.Parse("2006-01-02", ev.Dates.Start.LocalDate)
-				if err != nil {
-					log.Error("skipping event with unparseable date", "event", ev.Name, "dateTime", ev.Dates.Start.DateTime)
-					continue
-				}
-			}
-
-			var priceMin, priceMax float64
-			if len(ev.PriceRanges) > 0 {
-				priceMin = ev.PriceRanges[0].Min
-				priceMax = ev.PriceRanges[0].Max
-			}
-
-			shows = append(shows, store.Show{
-				ID:         showID,
-				Name:       ev.Name,
-				VenueID:    sv.ID,
-				ShowDate:   showDate,
-				TicketURL:  ev.URL,
-				PriceMin:   priceMin,
-				PriceMax:   priceMax,
-				Status:     ev.Dates.Status.Code,
-				DataSource: configuration.DataSourceTicketmaster,
-			})
-
-			for i, attr := range ev.Embedded.Attractions {
-				artistID := store.Slugify(attr.Name)
-				if artistID == "" {
-					continue
-				}
-
-				if !seenArtists[artistID] {
-					var imgURL string
-					if len(attr.Images) > 0 {
-						imgURL = attr.Images[0].URL
-					}
-					artists = append(artists, store.Artist{
-						ID:       artistID,
-						Name:     attr.Name,
-						ImageURL: imgURL,
-					})
-					seenArtists[artistID] = true
-				}
-
-				showArtists = append(showArtists, store.ShowArtist{
-					ShowID:       showID,
-					ArtistID:     artistID,
-					BillingOrder: i + 1,
-				})
-			}
-
-			for _, cl := range ev.Classifications {
-				if cl.Segment.Name == "" && cl.Genre.Name == "" && cl.SubGenre.Name == "" {
-					continue
-				}
-				classifications = append(classifications, store.ShowClassification{
-					ShowID:   showID,
-					Segment:  cl.Segment.Name,
-					Genre:    cl.Genre.Name,
-					SubGenre: cl.SubGenre.Name,
-				})
-			}
-		}
-	}
-
-	// 4. Persist everything.
-	if len(shows) > 0 {
-		if err := h.Venues.UpsertShows(dbCtx, shows); err != nil {
-			httpError(w, r, http.StatusInternalServerError, "internal error",
-				"failed to persist shows", "error", err)
-			return
-		}
-	}
-	if len(artists) > 0 {
-		if err := h.Venues.UpsertArtists(dbCtx, artists); err != nil {
-			httpError(w, r, http.StatusInternalServerError, "internal error",
-				"failed to persist artists", "error", err)
-			return
-		}
-	}
-	if len(showArtists) > 0 {
-		if err := h.Venues.UpsertShowArtists(dbCtx, showArtists); err != nil {
-			httpError(w, r, http.StatusInternalServerError, "internal error",
-				"failed to persist show-artist links", "error", err)
-			return
-		}
-	}
-	if len(classifications) > 0 {
-		if err := h.Venues.UpsertShowClassifications(dbCtx, classifications); err != nil {
-			httpError(w, r, http.StatusInternalServerError, "internal error",
-				"failed to persist show classifications", "error", err)
-			return
-		}
-	}
-
-	log.Info("venue sync complete", "venues", len(storeVenues), "shows", len(shows), "artists", len(artists))
-
-	// 5. Compute venue vibes from show artists + Last.fm tags.
-	vibesComputed := h.computeVenueVibes(syncCtx, ctx, storeVenues, log)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
-		"synced":          true,
-		"venues_count":    len(storeVenues),
-		"shows_count":     len(shows),
-		"vibes_computed":  vibesComputed,
+		"synced":         true,
+		"venues_count":   result.VenueCount,
+		"shows_count":    result.ShowCount,
+		"vibes_computed": result.VibesComputed,
 	})
 }
 
-// SyncVenueVibes computes vibe profiles for all venues without re-fetching
-// from Ticketmaster. Useful for local dev when you want to recompute vibes
-// without the full venue sync.
+// SyncVenueVibes recomputes vibe profiles for all venues without
+// re-fetching from Ticketmaster.
 func (h *VenueHandler) SyncVenueVibes(w http.ResponseWriter, r *http.Request) {
 	claims := middleware.ClaimsFromContext(r.Context())
 	if claims == nil {
@@ -341,20 +73,12 @@ func (h *VenueHandler) SyncVenueVibes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := r.Context()
-	log := observability.Logger(ctx)
-
-	venues, err := h.VenueReader.GetVenues(ctx)
+	computed, err := h.venues.SyncVenueVibes(r.Context())
 	if err != nil {
 		httpError(w, r, http.StatusInternalServerError, "internal error",
-			"failed to read venues for vibe computation", "error", err)
+			"venue vibe sync failed", "error", err)
 		return
 	}
-
-	syncCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), configuration.VenueSyncTimeout)
-	defer cancel()
-
-	computed := h.computeVenueVibes(syncCtx, ctx, venues, log)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
@@ -363,13 +87,7 @@ func (h *VenueHandler) SyncVenueVibes(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-type venueResponse struct {
-	store.Venue
-	Shows []store.ShowSummary `json:"shows"`
-	Vibes map[string]float32  `json:"vibes,omitempty"`
-}
-
-// GetVenues returns all cached venues with their upcoming shows.
+// GetVenues returns all cached venues with their upcoming shows and vibes.
 func (h *VenueHandler) GetVenues(w http.ResponseWriter, r *http.Request) {
 	claims := middleware.ClaimsFromContext(r.Context())
 	if claims == nil {
@@ -377,207 +95,16 @@ func (h *VenueHandler) GetVenues(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := r.Context()
-	venues, err := h.VenueReader.GetVenues(ctx)
+	venues, err := h.venues.GetVenues(r.Context())
 	if err != nil {
 		httpError(w, r, http.StatusInternalServerError, "internal error",
 			"failed to read venues", "error", err)
 		return
 	}
 
-	// Only include venues with shows to keep the response manageable.
-	var venueIDs []string
-	venueMap := make(map[string]store.Venue)
-	for _, v := range venues {
-		if v.ShowsTracked == 0 {
-			continue
-		}
-		venueIDs = append(venueIDs, v.ID)
-		venueMap[v.ID] = v
-	}
-
-	showsByVenue := make(map[string][]store.ShowSummary)
-	vibesByVenue := make(map[string]map[string]float32)
-	if len(venueIDs) > 0 {
-		var err error
-		showsByVenue, err = h.VenueReader.GetShowsForVenues(ctx, venueIDs)
-		if err != nil {
-			observability.Logger(ctx).Error("failed to read shows for venues", "error", err)
-		}
-		vibesByVenue, err = h.VenueReader.GetAllVenueVibes(ctx, venueIDs)
-		if err != nil {
-			observability.Logger(ctx).Error("failed to read venue vibes", "error", err)
-		}
-	}
-
-	var result []venueResponse
-	for _, id := range venueIDs {
-		result = append(result, venueResponse{
-			Venue: venueMap[id],
-			Shows: showsByVenue[id],
-			Vibes: vibesByVenue[id],
-		})
-	}
-
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
-		"venues": result,
-		"count":  len(result),
+		"venues": venues,
+		"count":  len(venues),
 	})
-}
-
-func mapVenues(tmVenues []ticketmaster.Venue) []store.Venue {
-	result := make([]store.Venue, 0, len(tmVenues))
-	for _, v := range tmVenues {
-		if v.Country.CountryCode != "" && v.Country.CountryCode != "US" {
-			continue // skip non-US venues (bad geocoding in TM data)
-		}
-		lat := v.Lat()
-		lng := v.Lng()
-		if lat == 0 && lng == 0 {
-			continue // skip venues without coordinates
-		}
-
-		var imgURL string
-		if len(v.Images) > 0 {
-			imgURL = v.Images[0].URL
-		}
-
-		result = append(result, store.Venue{
-			ID:            configuration.IDPrefixTicketmaster + v.ID,
-			Name:          v.Name,
-			Latitude:      lat,
-			Longitude:     lng,
-			Address:       v.Address.Line1,
-			City:          v.City.Name,
-			State:         v.State.StateCode,
-			ImageURL:      imgURL,
-			BoxOfficeInfo: v.BoxOfficeInfo,
-			ParkingDetail: v.ParkingDetail,
-			GeneralInfo:   v.GeneralInfo,
-			Ada:           v.Ada,
-			DataSource:    configuration.DataSourceTicketmaster,
-			TMID:          v.ID,
-		})
-	}
-	return result
-}
-
-// computeVenueVibes computes vibe profiles for all venues with shows.
-// For each venue's artists, it fetches Last.fm tags (cached where possible)
-// and computes a recency-weighted vibe vector.
-// Returns the number of venues with vibes computed.
-func (h *VenueHandler) computeVenueVibes(syncCtx, parentCtx context.Context, venues []store.Venue, log *slog.Logger) int {
-	// Collect venues with shows.
-	var venueIDs []string
-	for _, v := range venues {
-		if v.ShowsTracked > 0 {
-			venueIDs = append(venueIDs, v.ID)
-		}
-	}
-	if len(venueIDs) == 0 {
-		return 0
-	}
-
-	// Get all artists for all venues in one query.
-	allArtists, err := h.VenueReader.GetAllVenueArtists(syncCtx, venueIDs)
-	if err != nil {
-		log.Error("failed to get venue artists for vibe computation", "error", err)
-		return 0
-	}
-
-	// Collect unique artist names across all venues.
-	uniqueArtists := make(map[string]bool)
-	for _, artists := range allArtists {
-		for _, a := range artists {
-			uniqueArtists[strings.ToLower(a.ArtistName)] = true
-		}
-	}
-
-	// Fetch tags for all artists (cache-first, then Last.fm).
-	limiter := ratelimit.NewLimiter(configuration.LastFMRateLimit)
-	defer limiter.Stop()
-
-	artistTags := make(map[string][]lastfm.Tag)
-	cacheHits := 0
-	for name := range uniqueArtists {
-		if syncCtx.Err() != nil {
-			log.Error("venue vibe tag fetch timed out", "fetched", len(artistTags), "total", len(uniqueArtists))
-			break
-		}
-
-		cached, err := h.TagCache.GetCachedTags(syncCtx, name)
-		if err != nil {
-			log.Error("cache lookup failed", "artist", name, "error", err)
-		}
-		if cached != nil {
-			artistTags[name] = cached
-			cacheHits++
-			continue
-		}
-
-		if err := limiter.Wait(syncCtx); err != nil {
-			break
-		}
-		tags, err := h.LastFM.FetchArtistTags(syncCtx, name)
-		if err != nil {
-			log.Error("failed to fetch lastfm tags for venue vibe", "artist", name, "error", err)
-			continue
-		}
-
-		if len(tags) > 0 {
-			artistTags[name] = tags
-			if cacheErr := h.TagCache.UpsertArtistTags(syncCtx, name, tags); cacheErr != nil {
-				log.Error("failed to cache lastfm tags", "artist", name, "error", cacheErr)
-			}
-			continue
-		}
-
-		// Last.fm miss — fall back to Ticketmaster classifications.
-		tmTags, tmErr := h.TagCache.GetClassificationsForArtist(syncCtx, name)
-		if tmErr != nil {
-			log.Error("failed to get TM classifications", "artist", name, "error", tmErr)
-			continue
-		}
-		if len(tmTags) > 0 {
-			log.Info("using ticketmaster classifications as fallback", "artist", name, "tags", len(tmTags))
-			artistTags[name] = tmTags
-			if cacheErr := h.TagCache.UpsertArtistTagsWithSource(syncCtx, name, tmTags, store.TagSourceTicketmaster); cacheErr != nil {
-				log.Error("failed to cache TM tags", "artist", name, "error", cacheErr)
-			}
-		} else {
-			log.Info("no tag data available for artist", "artist", name, "sources", "lastfm,ticketmaster")
-		}
-	}
-	log.Info("venue vibe tag fetch complete", "unique_artists", len(uniqueArtists), "cache_hits", cacheHits)
-
-	// Compute vibes per venue.
-	dbCtx := context.WithoutCancel(parentCtx)
-	computed := 0
-	for _, venueID := range venueIDs {
-		venueArtists := allArtists[venueID]
-		if len(venueArtists) == 0 {
-			continue
-		}
-
-		// Convert store.VenueArtist to vibes.VenueArtist.
-		va := make([]vibes.VenueArtist, len(venueArtists))
-		for i, a := range venueArtists {
-			va[i] = vibes.VenueArtist{ArtistName: a.ArtistName, ShowDate: a.ShowDate}
-		}
-
-		venueVibe := vibes.ComputeVenueVibe(va, artistTags)
-		if len(venueVibe) == 0 {
-			continue
-		}
-
-		if err := h.VenueVibes.UpsertVenueVibes(dbCtx, venueID, venueVibe); err != nil {
-			log.Error("failed to persist venue vibes", "venue", venueID, "error", err)
-			continue
-		}
-		computed++
-	}
-
-	log.Info("venue vibes computed", "computed", computed, "total_venues", len(venueIDs))
-	return computed
 }

--- a/backend/internal/handlers/venues_test.go
+++ b/backend/internal/handlers/venues_test.go
@@ -3,141 +3,47 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
-	"github.com/pseudo/vibe-seeker/backend/internal/lastfm"
+	"github.com/pseudo/vibe-seeker/backend/internal/service"
 	"github.com/pseudo/vibe-seeker/backend/internal/store"
 	"github.com/pseudo/vibe-seeker/backend/internal/ticketmaster"
 )
 
-type mockVenueStore struct {
-	upsertVenuesCalled          bool
-	upsertShowsCalled           bool
-	upsertArtistsCalled         bool
-	upsertShowArtistsCalled     bool
-	upsertClassificationsCalled bool
-	venues                      []store.Venue
-	fetchedAt                   *time.Time
-	err                         error
+type mockVenueService struct {
+	syncResult     *service.VenueSyncResult
+	syncErr        error
+	syncVibesCount int
+	syncVibesErr   error
+	venues         []service.VenueWithDetails
+	venuesErr      error
 }
 
-func (m *mockVenueStore) UpsertVenues(_ context.Context, _ []store.Venue) error {
-	m.upsertVenuesCalled = true
-	return m.err
-}
-func (m *mockVenueStore) UpsertShows(_ context.Context, _ []store.Show) error {
-	m.upsertShowsCalled = true
-	return m.err
-}
-func (m *mockVenueStore) UpsertArtists(_ context.Context, _ []store.Artist) error {
-	m.upsertArtistsCalled = true
-	return m.err
-}
-func (m *mockVenueStore) UpsertShowArtists(_ context.Context, _ []store.ShowArtist) error {
-	m.upsertShowArtistsCalled = true
-	return m.err
-}
-func (m *mockVenueStore) UpsertShowClassifications(_ context.Context, _ []store.ShowClassification) error {
-	m.upsertClassificationsCalled = true
-	return m.err
-}
-func (m *mockVenueStore) GetVenueFetchedAt(_ context.Context, _ string) (*time.Time, error) {
-	return m.fetchedAt, nil
-}
-func (m *mockVenueStore) GetVenues(_ context.Context) ([]store.Venue, error) {
-	return m.venues, m.err
-}
-func (m *mockVenueStore) GetShowsForVenues(_ context.Context, _ []string) (map[string][]store.ShowSummary, error) {
-	return nil, nil
-}
-func (m *mockVenueStore) GetAllVenueArtists(_ context.Context, _ []string) (map[string][]store.VenueArtist, error) {
-	return nil, nil
-}
-func (m *mockVenueStore) GetAllVenueVibes(_ context.Context, _ []string) (map[string]map[string]float32, error) {
-	return nil, nil
-}
-func (m *mockVenueStore) UpsertVenueVibes(_ context.Context, _ string, _ map[string]float32) error {
-	return nil
+func (m *mockVenueService) SyncVenues(_ context.Context) (*service.VenueSyncResult, error) {
+	return m.syncResult, m.syncErr
 }
 
-func newMockLastFMForVenues() (*lastfm.Client, *mockTagCache) {
-	lfm := lastfm.NewClient("test-key")
-	return lfm, &mockTagCache{}
+func (m *mockVenueService) SyncVenueVibes(_ context.Context) (int, error) {
+	return m.syncVibesCount, m.syncVibesErr
 }
 
-func newMockTMServer(t *testing.T) (*ticketmaster.Client, *httptest.Server) {
-	t.Helper()
-
-	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-
-		switch r.URL.Path {
-		case "/venues.json":
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
-				"_embedded": map[string]interface{}{
-					"venues": []map[string]interface{}{
-						{
-							"id": "v1", "name": "Bowery Ballroom",
-							"location": map[string]string{"latitude": "40.7204", "longitude": "-73.9934"},
-							"address":  map[string]string{"line1": "6 Delancey St"},
-							"city":     map[string]string{"name": "New York"},
-							"state":    map[string]string{"stateCode": "NY"},
-						},
-					},
-				},
-				"page": map[string]int{"size": 200, "totalElements": 1, "totalPages": 1, "number": 0},
-			})
-		case "/events.json":
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
-				"_embedded": map[string]interface{}{
-					"events": []map[string]interface{}{
-						{
-							"id": "e1", "name": "Big Thief Live",
-							"dates": map[string]interface{}{
-								"start":  map[string]string{"dateTime": "2026-04-15T00:00:00Z"},
-								"status": map[string]string{"code": "onsale"},
-							},
-							"priceRanges": []map[string]interface{}{
-								{"min": 35.0, "max": 55.0, "currency": "USD"},
-							},
-							"classifications": []map[string]interface{}{
-								{
-									"segment":  map[string]string{"name": "Music"},
-									"genre":    map[string]string{"name": "Rock"},
-									"subGenre": map[string]string{"name": "Alternative Rock"},
-								},
-							},
-							"_embedded": map[string]interface{}{
-								"venues":      []map[string]interface{}{{"id": "v1", "name": "Bowery Ballroom"}},
-								"attractions": []map[string]interface{}{{"id": "a1", "name": "Big Thief"}},
-							},
-						},
-					},
-				},
-				"page": map[string]int{"size": 200, "totalElements": 1, "totalPages": 1, "number": 0},
-			})
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-
-	c := ticketmaster.NewClient("test-key")
-	c.BaseURL = mock.URL
-	c.HTTPClient = mock.Client()
-
-	return c, mock
+func (m *mockVenueService) GetVenues(_ context.Context) ([]service.VenueWithDetails, error) {
+	return m.venues, m.venuesErr
 }
 
 func TestSyncVenues_Success(t *testing.T) {
-	tm, mock := newMockTMServer(t)
-	defer mock.Close()
-	lfm, tc := newMockLastFMForVenues()
-
-	venueStore := &mockVenueStore{}
-	h, err := NewVenueHandler(tm, lfm, venueStore, tc)
+	h, err := NewVenueHandler(&mockVenueService{
+		syncResult: &service.VenueSyncResult{
+			Synced:        true,
+			VenueCount:    1,
+			ShowCount:     1,
+			VibesComputed: 1,
+		},
+	})
 	if err != nil {
 		t.Fatalf("NewVenueHandler: %v", err)
 	}
@@ -152,16 +58,6 @@ func TestSyncVenues_Success(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	if !venueStore.upsertVenuesCalled {
-		t.Error("expected UpsertVenues to be called")
-	}
-	if !venueStore.upsertShowsCalled {
-		t.Error("expected UpsertShows to be called")
-	}
-	if !venueStore.upsertArtistsCalled {
-		t.Error("expected UpsertArtists to be called")
-	}
-
 	var body map[string]interface{}
 	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
@@ -172,13 +68,13 @@ func TestSyncVenues_Success(t *testing.T) {
 }
 
 func TestSyncVenues_TTLSkip(t *testing.T) {
-	tm, mock := newMockTMServer(t)
-	defer mock.Close()
-	lfm, tc := newMockLastFMForVenues()
-
 	recent := time.Now().Add(-1 * time.Hour)
-	venueStore := &mockVenueStore{fetchedAt: &recent}
-	h, _ := NewVenueHandler(tm, lfm, venueStore, tc)
+	h, _ := NewVenueHandler(&mockVenueService{
+		syncResult: &service.VenueSyncResult{
+			Skipped:     true,
+			LastFetched: &recent,
+		},
+	})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/venues/sync", nil)
 	req = addTestClaims(t, req)
@@ -195,17 +91,10 @@ func TestSyncVenues_TTLSkip(t *testing.T) {
 	if body["synced"] != false {
 		t.Error("expected synced=false when data is fresh")
 	}
-	if venueStore.upsertVenuesCalled {
-		t.Error("expected UpsertVenues NOT to be called when data is fresh")
-	}
 }
 
 func TestSyncVenues_Unauthorized(t *testing.T) {
-	tm, mock := newMockTMServer(t)
-	defer mock.Close()
-	lfm, tc := newMockLastFMForVenues()
-
-	h, _ := NewVenueHandler(tm, lfm, &mockVenueStore{}, tc)
+	h, _ := NewVenueHandler(&mockVenueService{})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/venues/sync", nil)
 	rec := httptest.NewRecorder()
@@ -217,17 +106,30 @@ func TestSyncVenues_Unauthorized(t *testing.T) {
 	}
 }
 
-func TestGetVenues_Success(t *testing.T) {
-	tm, mock := newMockTMServer(t)
-	defer mock.Close()
-	lfm, tc := newMockLastFMForVenues()
+func TestSyncVenues_ServiceError(t *testing.T) {
+	h, _ := NewVenueHandler(&mockVenueService{
+		syncErr: errors.New("ticketmaster down"),
+	})
 
-	venueStore := &mockVenueStore{
-		venues: []store.Venue{
-			{ID: "tm_v1", Name: "Bowery Ballroom", Latitude: 40.7204, Longitude: -73.9934, ShowsTracked: 5},
-		},
+	req := httptest.NewRequest(http.MethodPost, "/api/venues/sync", nil)
+	req = addTestClaims(t, req)
+	rec := httptest.NewRecorder()
+
+	h.SyncVenues(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", rec.Code)
 	}
-	h, _ := NewVenueHandler(tm, lfm, venueStore, tc)
+}
+
+func TestGetVenues_Success(t *testing.T) {
+	h, _ := NewVenueHandler(&mockVenueService{
+		venues: []service.VenueWithDetails{
+			{
+				Venue: store.Venue{ID: "tm_v1", Name: "Bowery Ballroom", Latitude: 40.7204, Longitude: -73.9934, ShowsTracked: 5},
+			},
+		},
+	})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/venues", nil)
 	req = addTestClaims(t, req)
@@ -247,11 +149,7 @@ func TestGetVenues_Success(t *testing.T) {
 }
 
 func TestGetVenues_Unauthorized(t *testing.T) {
-	tm, mock := newMockTMServer(t)
-	defer mock.Close()
-	lfm, tc := newMockLastFMForVenues()
-
-	h, _ := NewVenueHandler(tm, lfm, &mockVenueStore{}, tc)
+	h, _ := NewVenueHandler(&mockVenueService{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/venues", nil)
 	rec := httptest.NewRecorder()
@@ -264,16 +162,9 @@ func TestGetVenues_Unauthorized(t *testing.T) {
 }
 
 func TestSyncVenueVibes_Success(t *testing.T) {
-	tm, mock := newMockTMServer(t)
-	defer mock.Close()
-	lfm, tc := newMockLastFMForVenues()
-
-	venueStore := &mockVenueStore{
-		venues: []store.Venue{
-			{ID: "tm_v1", Name: "Test Venue", ShowsTracked: 5},
-		},
-	}
-	h, err := NewVenueHandler(tm, lfm, venueStore, tc)
+	h, err := NewVenueHandler(&mockVenueService{
+		syncVibesCount: 3,
+	})
 	if err != nil {
 		t.Fatalf("NewVenueHandler: %v", err)
 	}
@@ -298,11 +189,7 @@ func TestSyncVenueVibes_Success(t *testing.T) {
 }
 
 func TestSyncVenueVibes_Unauthorized(t *testing.T) {
-	tm, mock := newMockTMServer(t)
-	defer mock.Close()
-	lfm, tc := newMockLastFMForVenues()
-
-	h, _ := NewVenueHandler(tm, lfm, &mockVenueStore{}, tc)
+	h, _ := NewVenueHandler(&mockVenueService{})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/venues/vibes", nil)
 	rec := httptest.NewRecorder()
@@ -340,7 +227,7 @@ func TestMapVenues_FiltersNonUS(t *testing.T) {
 		},
 	}
 
-	result := mapVenues(tmVenues)
+	result := service.MapVenues(tmVenues)
 	if len(result) != 1 {
 		t.Fatalf("expected 1 venue after filtering, got %d", len(result))
 	}
@@ -359,7 +246,7 @@ func TestMapVenues_EmptyCountryAllowed(t *testing.T) {
 		},
 	}
 
-	result := mapVenues(tmVenues)
+	result := service.MapVenues(tmVenues)
 	if len(result) != 1 {
 		t.Fatalf("expected 1 venue (empty country allowed), got %d", len(result))
 	}

--- a/backend/internal/handlers/vibe.go
+++ b/backend/internal/handlers/vibe.go
@@ -5,76 +5,30 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"strings"
-	"time"
 
-	"github.com/pseudo/vibe-seeker/backend/internal/configuration"
-	"github.com/pseudo/vibe-seeker/backend/internal/lastfm"
 	"github.com/pseudo/vibe-seeker/backend/internal/middleware"
-	"github.com/pseudo/vibe-seeker/backend/internal/observability"
-	"github.com/pseudo/vibe-seeker/backend/internal/ratelimit"
-	"github.com/pseudo/vibe-seeker/backend/internal/spotify"
-	"github.com/pseudo/vibe-seeker/backend/internal/store"
-	"github.com/pseudo/vibe-seeker/backend/internal/vibes"
+	"github.com/pseudo/vibe-seeker/backend/internal/service"
 )
 
-// TokenStore reads and writes Spotify tokens.
-type TokenStore interface {
-	GetTokens(ctx context.Context, userID string) (*store.UserTokens, error)
-	UpdateTokens(ctx context.Context, userID, accessToken, refreshToken string, tokenExpiry int) error
+// VibeManager provides vibe sync and read operations.
+type VibeManager interface {
+	SyncVibe(ctx context.Context, userID string) (*service.VibeSyncResult, error)
+	GetVibe(ctx context.Context, userID string) (map[string]float32, error)
 }
 
-// VibeStore reads and writes user vibe profiles.
-type VibeStore interface {
-	UpsertVibes(ctx context.Context, userID string, vibes map[string]float32) error
-	GetVibes(ctx context.Context, userID string) (map[string]float32, error)
-}
-
-// TagCache provides read-through caching for artist tags.
-type TagCache interface {
-	GetCachedTags(ctx context.Context, artistName string) ([]lastfm.Tag, error)
-	UpsertArtistTags(ctx context.Context, artistName string, tags []lastfm.Tag) error
-	UpsertArtistTagsWithSource(ctx context.Context, artistName string, tags []lastfm.Tag, source string) error
-	GetClassificationsForArtist(ctx context.Context, artistName string) ([]lastfm.Tag, error)
-}
-
-// VibeHandler orchestrates vibe profile syncing via Spotify (top artists)
-// and Last.fm (genre/tag enrichment).
+// VibeHandler handles HTTP vibe endpoints.
 type VibeHandler struct {
-	Spotify  *spotify.Client
-	LastFM   *lastfm.Client
-	Tokens   TokenStore
-	Vibes    VibeStore
-	TagCache TagCache
+	vibes VibeManager
 }
 
-func NewVibeHandler(sp *spotify.Client, lfm *lastfm.Client, tokens TokenStore, vibes VibeStore, tagCache TagCache) (*VibeHandler, error) {
-	if sp == nil {
-		return nil, errors.New("vibe: nil spotify client")
-	}
-	if lfm == nil {
-		return nil, errors.New("vibe: nil lastfm client")
-	}
-	if tokens == nil {
-		return nil, errors.New("vibe: nil token store")
-	}
+func NewVibeHandler(vibes VibeManager) (*VibeHandler, error) {
 	if vibes == nil {
-		return nil, errors.New("vibe: nil vibe store")
+		return nil, errors.New("vibe: nil vibe service")
 	}
-	if tagCache == nil {
-		return nil, errors.New("vibe: nil tag cache")
-	}
-	return &VibeHandler{
-		Spotify:  sp,
-		LastFM:   lfm,
-		Tokens:   tokens,
-		Vibes:    vibes,
-		TagCache: tagCache,
-	}, nil
+	return &VibeHandler{vibes: vibes}, nil
 }
 
-// SyncVibe fetches the user's top artists from Spotify, enriches them with
-// Last.fm tags, computes weighted tag scores, and persists the result.
+// SyncVibe triggers a vibe profile sync for the authenticated user.
 func (h *VibeHandler) SyncVibe(w http.ResponseWriter, r *http.Request) {
 	claims := middleware.ClaimsFromContext(r.Context())
 	if claims == nil {
@@ -82,134 +36,17 @@ func (h *VibeHandler) SyncVibe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := r.Context()
-
-	accessToken, err := h.ensureValidToken(ctx, claims.SpotifyID)
+	result, err := h.vibes.SyncVibe(r.Context(), claims.SpotifyID)
 	if err != nil {
-		httpError(w, r, http.StatusBadGateway, "failed to authenticate with spotify",
-			"failed to get valid token", "user", claims.SpotifyID, "error", err)
+		httpError(w, r, http.StatusBadGateway, "failed to sync vibes",
+			"vibe sync failed", "user", claims.SpotifyID, "error", err)
 		return
 	}
-
-	mediumResp, err := h.Spotify.FetchTopArtists(ctx, accessToken, "medium_term", 50)
-	if err != nil {
-		httpError(w, r, http.StatusBadGateway, "failed to fetch top artists",
-			"failed to fetch medium-term top artists", "error", err)
-		return
-	}
-
-	shortResp, err := h.Spotify.FetchTopArtists(ctx, accessToken, "short_term", 50)
-	if err != nil {
-		httpError(w, r, http.StatusBadGateway, "failed to fetch top artists",
-			"failed to fetch short-term top artists", "error", err)
-		return
-	}
-
-	// Build weighted artists and collect unique names.
-	var weighted []vibes.WeightedArtist
-	seen := make(map[string]bool)
-
-	for i, a := range mediumResp.Items {
-		rankWeight := float32(1.0) - float32(i)*0.02
-		if rankWeight < 0 {
-			rankWeight = 0
-		}
-		weighted = append(weighted, vibes.WeightedArtist{
-			Name: a.Name, Weight: rankWeight * 1.0, // medium_term multiplier
-		})
-		seen[strings.ToLower(a.Name)] = true
-	}
-	for i, a := range shortResp.Items {
-		rankWeight := float32(1.0) - float32(i)*0.02
-		if rankWeight < 0 {
-			rankWeight = 0
-		}
-		weighted = append(weighted, vibes.WeightedArtist{
-			Name: a.Name, Weight: rankWeight * 0.5, // short_term multiplier
-		})
-		seen[strings.ToLower(a.Name)] = true
-	}
-
-	// Fetch Last.fm tags for each unique artist, using the DB cache first.
-	tagCtx, tagCancel := context.WithTimeout(context.WithoutCancel(ctx), configuration.VibeSyncTimeout)
-	defer tagCancel()
-
-	limiter := ratelimit.NewLimiter(configuration.LastFMRateLimit)
-	defer limiter.Stop()
-
-	artistTags := make(map[string][]lastfm.Tag)
-	cacheHits := 0
-	for name := range seen {
-		if tagCtx.Err() != nil {
-			observability.Logger(ctx).Error("lastfm tag fetch timed out", "fetched", len(artistTags), "total", len(seen))
-			break
-		}
-
-		// Check cache first.
-		cached, err := h.TagCache.GetCachedTags(tagCtx, name)
-		if err != nil {
-			observability.Logger(ctx).Error("cache lookup failed", "artist", name, "error", err)
-		}
-		if cached != nil {
-			artistTags[name] = cached
-			cacheHits++
-			continue
-		}
-
-		// Cache miss — fetch from Last.fm (rate-limited).
-		if err := limiter.Wait(tagCtx); err != nil {
-			observability.Logger(ctx).Error("lastfm tag fetch timed out during wait", "error", err)
-			break
-		}
-		tags, err := h.LastFM.FetchArtistTags(tagCtx, name)
-		if err != nil {
-			observability.Logger(ctx).Error("failed to fetch lastfm tags", "artist", name, "error", err)
-			continue
-		}
-
-		if len(tags) > 0 {
-			artistTags[name] = tags
-			if cacheErr := h.TagCache.UpsertArtistTags(tagCtx, name, tags); cacheErr != nil {
-				observability.Logger(ctx).Error("failed to cache lastfm tags", "artist", name, "error", cacheErr)
-			}
-			continue
-		}
-
-		// Last.fm miss — fall back to Ticketmaster classifications.
-		tmTags, tmErr := h.TagCache.GetClassificationsForArtist(tagCtx, name)
-		if tmErr != nil {
-			observability.Logger(ctx).Error("failed to get TM classifications", "artist", name, "error", tmErr)
-			continue
-		}
-		if len(tmTags) > 0 {
-			observability.Logger(ctx).Info("using ticketmaster classifications as fallback", "artist", name, "tags", len(tmTags))
-			artistTags[name] = tmTags
-			if cacheErr := h.TagCache.UpsertArtistTagsWithSource(tagCtx, name, tmTags, store.TagSourceTicketmaster); cacheErr != nil {
-				observability.Logger(ctx).Error("failed to cache TM tags", "artist", name, "error", cacheErr)
-			}
-		} else {
-			observability.Logger(ctx).Info("no tag data available for artist", "artist", name)
-		}
-	}
-	observability.Logger(ctx).Info("tag fetch complete", "total", len(seen), "cache_hits", cacheHits, "api_calls", len(seen)-cacheHits)
-
-	weights := vibes.ComputeVibes(artistTags, weighted)
-
-	// Use a fresh context for the DB write — the data is already in memory,
-	// so we don't want the Last.fm timeout to prevent saving results.
-	dbCtx := context.WithoutCancel(ctx)
-	if err := h.Vibes.UpsertVibes(dbCtx, claims.SpotifyID, weights); err != nil {
-		httpError(w, r, http.StatusInternalServerError, "internal error",
-			"failed to persist vibe weights", "error", err)
-		return
-	}
-
-	observability.Logger(ctx).Info("vibe sync complete", "user", claims.SpotifyID, "tags", len(weights))
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
-		"synced":      true,
-		"genre_count": len(weights),
+		"synced":     true,
+		"vibe_count": result.VibeCount,
 	})
 }
 
@@ -221,7 +58,7 @@ func (h *VibeHandler) GetVibe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	vibes, err := h.Vibes.GetVibes(r.Context(), claims.SpotifyID)
+	vibes, err := h.vibes.GetVibe(r.Context(), claims.SpotifyID)
 	if err != nil {
 		httpError(w, r, http.StatusInternalServerError, "internal error",
 			"failed to read vibe weights", "error", err)
@@ -230,31 +67,7 @@ func (h *VibeHandler) GetVibe(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
-		"genres":      vibes,
-		"genre_count": len(vibes),
+		"vibes":      vibes,
+		"vibe_count": len(vibes),
 	})
-}
-
-// ensureValidToken returns a valid access token, refreshing it if expired.
-func (h *VibeHandler) ensureValidToken(ctx context.Context, userID string) (string, error) {
-	tokens, err := h.Tokens.GetTokens(ctx, userID)
-	if err != nil {
-		return "", err
-	}
-
-	if int64(tokens.TokenExpiry) <= time.Now().Unix()+configuration.TokenRefreshThreshold {
-		refreshed, err := h.Spotify.RefreshToken(ctx, tokens.RefreshToken)
-		if err != nil {
-			return "", err
-		}
-
-		newExpiry := int(time.Now().Unix()) + refreshed.ExpiresIn
-		if err := h.Tokens.UpdateTokens(ctx, userID, refreshed.AccessToken, refreshed.RefreshToken, newExpiry); err != nil {
-			return "", err
-		}
-
-		return refreshed.AccessToken, nil
-	}
-
-	return tokens.AccessToken, nil
 }

--- a/backend/internal/handlers/vibe_test.go
+++ b/backend/internal/handlers/vibe_test.go
@@ -125,7 +125,7 @@ func TestGetVibe_Success(t *testing.T) {
 
 	vibes, ok := body["vibes"].(map[string]interface{})
 	if !ok {
-		t.Fatal("expected genres map in response")
+		t.Fatal("expected vibes map in response")
 	}
 	if vibes["rock"] == nil {
 		t.Error("expected 'rock' in vibes")

--- a/backend/internal/handlers/vibe_test.go
+++ b/backend/internal/handlers/vibe_test.go
@@ -3,285 +3,29 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/pseudo/vibe-seeker/backend/internal/auth"
-	"github.com/pseudo/vibe-seeker/backend/internal/lastfm"
 	"github.com/pseudo/vibe-seeker/backend/internal/middleware"
-	"github.com/pseudo/vibe-seeker/backend/internal/spotify"
-	"github.com/pseudo/vibe-seeker/backend/internal/store"
+	"github.com/pseudo/vibe-seeker/backend/internal/service"
 )
 
-type mockTokenStore struct {
-	tokens       *store.UserTokens
-	err          error
-	updateCalled bool
+type mockVibeService struct {
+	syncResult *service.VibeSyncResult
+	syncErr    error
+	getVibes   map[string]float32
+	getErr     error
 }
 
-func (m *mockTokenStore) GetTokens(_ context.Context, _ string) (*store.UserTokens, error) {
-	return m.tokens, m.err
+func (m *mockVibeService) SyncVibe(_ context.Context, _ string) (*service.VibeSyncResult, error) {
+	return m.syncResult, m.syncErr
 }
 
-func (m *mockTokenStore) UpdateTokens(_ context.Context, _, _, _ string, _ int) error {
-	m.updateCalled = true
-	return m.err
-}
-
-type mockVibeStore struct {
-	upsertCalled bool
-	upsertVibes  map[string]float32
-	upsertErr    error
-	getVibes     map[string]float32
-	getErr       error
-}
-
-func (m *mockVibeStore) UpsertVibes(_ context.Context, _ string, vibes map[string]float32) error {
-	m.upsertCalled = true
-	m.upsertVibes = vibes
-	return m.upsertErr
-}
-
-func (m *mockVibeStore) GetVibes(_ context.Context, _ string) (map[string]float32, error) {
+func (m *mockVibeService) GetVibe(_ context.Context, _ string) (map[string]float32, error) {
 	return m.getVibes, m.getErr
-}
-
-type mockTagCache struct {
-	tags map[string][]lastfm.Tag
-}
-
-func (m *mockTagCache) GetCachedTags(_ context.Context, artistName string) ([]lastfm.Tag, error) {
-	if tags, ok := m.tags[artistName]; ok {
-		return tags, nil
-	}
-	return nil, nil
-}
-
-func (m *mockTagCache) UpsertArtistTags(_ context.Context, artistName string, tags []lastfm.Tag) error {
-	if m.tags == nil {
-		m.tags = make(map[string][]lastfm.Tag)
-	}
-	m.tags[artistName] = tags
-	return nil
-}
-
-func (m *mockTagCache) UpsertArtistTagsWithSource(_ context.Context, artistName string, tags []lastfm.Tag, _ string) error {
-	return m.UpsertArtistTags(context.Background(), artistName, tags)
-}
-
-func (m *mockTagCache) GetClassificationsForArtist(_ context.Context, _ string) ([]lastfm.Tag, error) {
-	return nil, nil
-}
-
-func newMockServers(t *testing.T) (*spotify.Client, *lastfm.Client, func()) {
-	t.Helper()
-
-	spotifyMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/v1/me/top/artists":
-			timeRange := r.URL.Query().Get("time_range")
-			var artists []spotify.Artist
-			if timeRange == "medium_term" {
-				artists = []spotify.Artist{
-					{ID: "a1", Name: "Artist One"},
-					{ID: "a2", Name: "Artist Two"},
-				}
-			} else {
-				artists = []spotify.Artist{
-					{ID: "a3", Name: "Artist Three"},
-				}
-			}
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{"items": artists})
-		case "/api/token":
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
-				"access_token":  "refreshed-token",
-				"refresh_token": "new-refresh",
-				"expires_in":    3600,
-			})
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-
-	lastfmMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"toptags": map[string]interface{}{
-				"tag": []map[string]interface{}{
-					{"name": "rock", "count": 100},
-					{"name": "indie", "count": 80},
-				},
-			},
-		})
-	}))
-
-	sp := spotify.NewClient("client-id", "client-secret", "http://localhost:8080/callback")
-	sp.TopArtistsURL = spotifyMock.URL + "/v1/me/top/artists"
-	sp.TokenURL = spotifyMock.URL + "/api/token"
-	sp.HTTPClient = spotifyMock.Client()
-
-	lfm := lastfm.NewClient("test-key")
-	lfm.BaseURL = lastfmMock.URL + "/"
-	lfm.HTTPClient = lastfmMock.Client()
-
-	cleanup := func() {
-		spotifyMock.Close()
-		lastfmMock.Close()
-	}
-
-	return sp, lfm, cleanup
-}
-
-func TestSyncVibe_Success(t *testing.T) {
-	sp, lfm, cleanup := newMockServers(t)
-	defer cleanup()
-
-	vibeStore := &mockVibeStore{}
-	h, err := NewVibeHandler(sp, lfm,
-		&mockTokenStore{tokens: &store.UserTokens{
-			AccessToken: "valid-token", RefreshToken: "refresh", TokenExpiry: int(time.Now().Unix()) + 3600,
-		}},
-		vibeStore,
-		&mockTagCache{},
-	)
-	if err != nil {
-		t.Fatalf("NewVibeHandler: %v", err)
-	}
-
-	req := httptest.NewRequest(http.MethodPost, "/api/vibe/sync", nil)
-	req = addTestClaims(t, req)
-	rec := httptest.NewRecorder()
-
-	h.SyncVibe(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
-	}
-
-	if !vibeStore.upsertCalled {
-		t.Fatal("expected UpsertVibes to be called")
-	}
-
-	if _, ok := vibeStore.upsertVibes["rock"]; !ok {
-		t.Error("expected 'rock' in vibe weights (from Last.fm tags)")
-	}
-
-	var body map[string]interface{}
-	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
-		t.Fatalf("failed to decode response: %v", err)
-	}
-	if body["synced"] != true {
-		t.Error("expected synced=true")
-	}
-}
-
-func TestSyncVibe_Unauthorized(t *testing.T) {
-	sp, lfm, cleanup := newMockServers(t)
-	defer cleanup()
-
-	h, _ := NewVibeHandler(sp, lfm,
-		&mockTokenStore{tokens: &store.UserTokens{}},
-		&mockVibeStore{},
-		&mockTagCache{},
-	)
-
-	req := httptest.NewRequest(http.MethodPost, "/api/vibe/sync", nil)
-	rec := httptest.NewRecorder()
-
-	h.SyncVibe(rec, req)
-
-	if rec.Code != http.StatusUnauthorized {
-		t.Errorf("expected 401, got %d", rec.Code)
-	}
-}
-
-func TestSyncVibe_TokenRefresh(t *testing.T) {
-	sp, lfm, cleanup := newMockServers(t)
-	defer cleanup()
-
-	tokenStore := &mockTokenStore{tokens: &store.UserTokens{
-		AccessToken: "expired-token", RefreshToken: "refresh", TokenExpiry: int(time.Now().Unix()) - 100,
-	}}
-	h, _ := NewVibeHandler(sp, lfm,
-		tokenStore,
-		&mockVibeStore{},
-		&mockTagCache{},
-	)
-
-	req := httptest.NewRequest(http.MethodPost, "/api/vibe/sync", nil)
-	req = addTestClaims(t, req)
-	rec := httptest.NewRecorder()
-
-	h.SyncVibe(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
-	}
-
-	if !tokenStore.updateCalled {
-		t.Error("expected UpdateTokens to be called for expired token")
-	}
-}
-
-func TestGetVibe_Success(t *testing.T) {
-	sp, lfm, cleanup := newMockServers(t)
-	defer cleanup()
-
-	vibeStore := &mockVibeStore{
-		getVibes: map[string]float32{"rock": 1.0, "indie": 0.7},
-	}
-	h, _ := NewVibeHandler(sp, lfm,
-		&mockTokenStore{tokens: &store.UserTokens{}},
-		vibeStore,
-		&mockTagCache{},
-	)
-
-	req := httptest.NewRequest(http.MethodGet, "/api/vibe", nil)
-	req = addTestClaims(t, req)
-	rec := httptest.NewRecorder()
-
-	h.GetVibe(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", rec.Code)
-	}
-
-	var body map[string]interface{}
-	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
-		t.Fatalf("failed to decode response: %v", err)
-	}
-
-	vibes, ok := body["genres"].(map[string]interface{})
-	if !ok {
-		t.Fatal("expected genres map in response")
-	}
-	if vibes["rock"] == nil {
-		t.Error("expected 'rock' in vibes")
-	}
-}
-
-func TestGetVibe_Unauthorized(t *testing.T) {
-	sp, lfm, cleanup := newMockServers(t)
-	defer cleanup()
-
-	h, _ := NewVibeHandler(sp, lfm,
-		&mockTokenStore{tokens: &store.UserTokens{}},
-		&mockVibeStore{},
-		&mockTagCache{},
-	)
-
-	req := httptest.NewRequest(http.MethodGet, "/api/vibe", nil)
-	rec := httptest.NewRecorder()
-
-	h.GetVibe(rec, req)
-
-	if rec.Code != http.StatusUnauthorized {
-		t.Errorf("expected 401, got %d", rec.Code)
-	}
 }
 
 // addTestClaims creates a JWT and injects claims into the request context
@@ -298,4 +42,105 @@ func addTestClaims(t *testing.T, req *http.Request) *http.Request {
 	}
 	ctx := middleware.ContextWithClaims(req.Context(), claims)
 	return req.WithContext(ctx)
+}
+
+func TestSyncVibe_Success(t *testing.T) {
+	h, err := NewVibeHandler(&mockVibeService{
+		syncResult: &service.VibeSyncResult{VibeCount: 5},
+	})
+	if err != nil {
+		t.Fatalf("NewVibeHandler: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/vibe/sync", nil)
+	req = addTestClaims(t, req)
+	rec := httptest.NewRecorder()
+
+	h.SyncVibe(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var body map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if body["synced"] != true {
+		t.Error("expected synced=true")
+	}
+	if body["vibe_count"] != float64(5) {
+		t.Errorf("expected vibe_count=5, got %v", body["vibe_count"])
+	}
+}
+
+func TestSyncVibe_Unauthorized(t *testing.T) {
+	h, _ := NewVibeHandler(&mockVibeService{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/vibe/sync", nil)
+	rec := httptest.NewRecorder()
+
+	h.SyncVibe(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", rec.Code)
+	}
+}
+
+func TestSyncVibe_ServiceError(t *testing.T) {
+	h, _ := NewVibeHandler(&mockVibeService{
+		syncErr: errors.New("spotify down"),
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/vibe/sync", nil)
+	req = addTestClaims(t, req)
+	rec := httptest.NewRecorder()
+
+	h.SyncVibe(rec, req)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("expected 502, got %d", rec.Code)
+	}
+}
+
+func TestGetVibe_Success(t *testing.T) {
+	h, _ := NewVibeHandler(&mockVibeService{
+		getVibes: map[string]float32{"rock": 1.0, "indie": 0.7},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/vibe", nil)
+	req = addTestClaims(t, req)
+	rec := httptest.NewRecorder()
+
+	h.GetVibe(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var body map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	vibes, ok := body["vibes"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected genres map in response")
+	}
+	if vibes["rock"] == nil {
+		t.Error("expected 'rock' in vibes")
+	}
+}
+
+func TestGetVibe_Unauthorized(t *testing.T) {
+	h, _ := NewVibeHandler(&mockVibeService{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/vibe", nil)
+	rec := httptest.NewRecorder()
+
+	h.GetVibe(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", rec.Code)
+	}
 }

--- a/backend/internal/service/auth.go
+++ b/backend/internal/service/auth.go
@@ -1,0 +1,166 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/pseudo/vibe-seeker/backend/internal/auth"
+	"github.com/pseudo/vibe-seeker/backend/internal/spotify"
+)
+
+// UserUpserter persists user data on login.
+type UserUpserter interface {
+	UpsertUser(ctx context.Context, id, displayName, accessToken, refreshToken string, tokenExpiry int) error
+}
+
+// SpotifyOAuth handles Spotify OAuth token exchange and profile fetching.
+type SpotifyOAuth interface {
+	ExchangeCode(ctx context.Context, code string) (*spotify.TokenResponse, error)
+	FetchProfile(ctx context.Context, accessToken string) (*spotify.Profile, error)
+}
+
+// LoginResult contains the session data produced by a successful login.
+type LoginResult struct {
+	JWT         string
+	UserID      string
+	DisplayName string
+}
+
+// TurnstileVerifyURL is the Cloudflare Turnstile verification endpoint.
+// Exported so tests can override it with a mock server.
+var TurnstileVerifyURL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+
+// ErrTurnstileRejected indicates Cloudflare explicitly rejected the token.
+var ErrTurnstileRejected = errors.New("turnstile token rejected")
+
+// AuthService handles authentication business logic: Spotify OAuth,
+// anonymous login via Turnstile, and user persistence.
+type AuthService struct {
+	spotify            SpotifyOAuth
+	users              UserUpserter
+	jwtSecret          string
+	turnstileSecretKey string
+}
+
+// NewAuthService creates an AuthService.
+func NewAuthService(sp SpotifyOAuth, users UserUpserter, jwtSecret, turnstileSecretKey string) (*AuthService, error) {
+	if sp == nil {
+		return nil, errors.New("auth service: nil spotify client")
+	}
+	if users == nil {
+		return nil, errors.New("auth service: nil user store")
+	}
+	return &AuthService{
+		spotify:            sp,
+		users:              users,
+		jwtSecret:          jwtSecret,
+		turnstileSecretKey: turnstileSecretKey,
+	}, nil
+}
+
+// LoginWithSpotify exchanges an OAuth code for tokens, fetches the Spotify
+// profile, persists the user, and returns a signed JWT.
+func (s *AuthService) LoginWithSpotify(ctx context.Context, code string) (*LoginResult, error) {
+	tokenResp, err := s.spotify.ExchangeCode(ctx, code)
+	if err != nil {
+		return nil, fmt.Errorf("exchanging code: %w", err)
+	}
+
+	profile, err := s.spotify.FetchProfile(ctx, tokenResp.AccessToken)
+	if err != nil {
+		return nil, fmt.Errorf("fetching profile: %w", err)
+	}
+
+	tokenExpiry := int(time.Now().Unix()) + tokenResp.ExpiresIn
+	if err := s.users.UpsertUser(ctx, profile.ID, profile.DisplayName, tokenResp.AccessToken, tokenResp.RefreshToken, tokenExpiry); err != nil {
+		return nil, fmt.Errorf("persisting user: %w", err)
+	}
+
+	jwt, err := auth.CreateToken(s.jwtSecret, profile.ID, profile.DisplayName)
+	if err != nil {
+		return nil, fmt.Errorf("creating token: %w", err)
+	}
+
+	return &LoginResult{
+		JWT:         jwt,
+		UserID:      profile.ID,
+		DisplayName: profile.DisplayName,
+	}, nil
+}
+
+// LoginAnonymous verifies a Cloudflare Turnstile token, generates an
+// anonymous identity, and returns a signed JWT.
+func (s *AuthService) LoginAnonymous(ctx context.Context, turnstileToken string) (*LoginResult, error) {
+	if err := s.verifyTurnstile(ctx, turnstileToken); err != nil {
+		return nil, err
+	}
+
+	anonID, err := generateAnonymousID()
+	if err != nil {
+		return nil, fmt.Errorf("generating anonymous id: %w", err)
+	}
+
+	jwt, err := auth.CreateToken(s.jwtSecret, anonID, "Explorer")
+	if err != nil {
+		return nil, fmt.Errorf("creating anonymous token: %w", err)
+	}
+
+	return &LoginResult{
+		JWT:         jwt,
+		UserID:      anonID,
+		DisplayName: "Explorer",
+	}, nil
+}
+
+// verifyTurnstile validates a Turnstile token with the Cloudflare API.
+func (s *AuthService) verifyTurnstile(ctx context.Context, token string) error {
+	if s.turnstileSecretKey == "" {
+		return fmt.Errorf("turnstile secret key not configured")
+	}
+
+	form := url.Values{
+		"secret":   {s.turnstileSecretKey},
+		"response": {token},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, TurnstileVerifyURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("creating turnstile request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("calling turnstile API: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result struct {
+		Success bool `json:"success"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("decoding turnstile response: %w", err)
+	}
+
+	if !result.Success {
+		return ErrTurnstileRejected
+	}
+	return nil
+}
+
+// generateAnonymousID creates a random anonymous user identifier.
+func generateAnonymousID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return "anon-" + hex.EncodeToString(b), nil
+}

--- a/backend/internal/service/auth.go
+++ b/backend/internal/service/auth.go
@@ -143,6 +143,10 @@ func (s *AuthService) verifyTurnstile(ctx context.Context, token string) error {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("turnstile API returned HTTP %d", resp.StatusCode)
+	}
+
 	var result struct {
 		Success bool `json:"success"`
 	}

--- a/backend/internal/service/auth_test.go
+++ b/backend/internal/service/auth_test.go
@@ -1,0 +1,203 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/pseudo/vibe-seeker/backend/internal/spotify"
+)
+
+type mockSpotifyOAuth struct {
+	tokenResp  *spotify.TokenResponse
+	profile    *spotify.Profile
+	exchangeErr error
+	profileErr  error
+}
+
+func (m *mockSpotifyOAuth) ExchangeCode(_ context.Context, _ string) (*spotify.TokenResponse, error) {
+	return m.tokenResp, m.exchangeErr
+}
+
+func (m *mockSpotifyOAuth) FetchProfile(_ context.Context, _ string) (*spotify.Profile, error) {
+	return m.profile, m.profileErr
+}
+
+type mockUserUpserter struct {
+	called bool
+	err    error
+}
+
+func (m *mockUserUpserter) UpsertUser(_ context.Context, _, _, _, _ string, _ int) error {
+	m.called = true
+	return m.err
+}
+
+func TestLoginWithSpotify_Success(t *testing.T) {
+	users := &mockUserUpserter{}
+	svc, err := NewAuthService(
+		&mockSpotifyOAuth{
+			tokenResp: &spotify.TokenResponse{
+				AccessToken: "at", RefreshToken: "rt", ExpiresIn: 3600,
+			},
+			profile: &spotify.Profile{ID: "spotify123", DisplayName: "Test User"},
+		},
+		users, "jwt-secret", "",
+	)
+	if err != nil {
+		t.Fatalf("NewAuthService: %v", err)
+	}
+
+	result, err := svc.LoginWithSpotify(context.Background(), "test-code")
+	if err != nil {
+		t.Fatalf("LoginWithSpotify: %v", err)
+	}
+
+	if result.UserID != "spotify123" {
+		t.Errorf("UserID = %q, want %q", result.UserID, "spotify123")
+	}
+	if result.DisplayName != "Test User" {
+		t.Errorf("DisplayName = %q, want %q", result.DisplayName, "Test User")
+	}
+	if result.JWT == "" {
+		t.Error("expected non-empty JWT")
+	}
+	if !users.called {
+		t.Error("expected UpsertUser to be called")
+	}
+}
+
+func TestLoginWithSpotify_ExchangeError(t *testing.T) {
+	svc, _ := NewAuthService(
+		&mockSpotifyOAuth{exchangeErr: errors.New("bad code")},
+		&mockUserUpserter{}, "jwt-secret", "",
+	)
+
+	_, err := svc.LoginWithSpotify(context.Background(), "bad-code")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "exchanging code") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoginWithSpotify_ProfileError(t *testing.T) {
+	svc, _ := NewAuthService(
+		&mockSpotifyOAuth{
+			tokenResp:  &spotify.TokenResponse{AccessToken: "at"},
+			profileErr: errors.New("profile error"),
+		},
+		&mockUserUpserter{}, "jwt-secret", "",
+	)
+
+	_, err := svc.LoginWithSpotify(context.Background(), "code")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "fetching profile") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoginWithSpotify_UpsertError(t *testing.T) {
+	svc, _ := NewAuthService(
+		&mockSpotifyOAuth{
+			tokenResp: &spotify.TokenResponse{AccessToken: "at", RefreshToken: "rt", ExpiresIn: 3600},
+			profile:   &spotify.Profile{ID: "id1", DisplayName: "Name"},
+		},
+		&mockUserUpserter{err: errors.New("db error")}, "jwt-secret", "",
+	)
+
+	_, err := svc.LoginWithSpotify(context.Background(), "code")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "persisting user") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoginAnonymous_Success(t *testing.T) {
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]bool{"success": true})
+	}))
+	defer mock.Close()
+
+	original := TurnstileVerifyURL
+	TurnstileVerifyURL = mock.URL
+	defer func() { TurnstileVerifyURL = original }()
+
+	svc, _ := NewAuthService(
+		&mockSpotifyOAuth{},
+		&mockUserUpserter{}, "jwt-secret", "test-secret",
+	)
+
+	result, err := svc.LoginAnonymous(context.Background(), "token")
+	if err != nil {
+		t.Fatalf("LoginAnonymous: %v", err)
+	}
+
+	if !strings.HasPrefix(result.UserID, "anon-") {
+		t.Errorf("expected anonymous UserID prefix, got %q", result.UserID)
+	}
+	if result.DisplayName != "Explorer" {
+		t.Errorf("DisplayName = %q, want %q", result.DisplayName, "Explorer")
+	}
+	if result.JWT == "" {
+		t.Error("expected non-empty JWT")
+	}
+}
+
+func TestLoginAnonymous_TurnstileRejected(t *testing.T) {
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]bool{"success": false})
+	}))
+	defer mock.Close()
+
+	original := TurnstileVerifyURL
+	TurnstileVerifyURL = mock.URL
+	defer func() { TurnstileVerifyURL = original }()
+
+	svc, _ := NewAuthService(
+		&mockSpotifyOAuth{},
+		&mockUserUpserter{}, "jwt-secret", "test-secret",
+	)
+
+	_, err := svc.LoginAnonymous(context.Background(), "bad-token")
+	if !errors.Is(err, ErrTurnstileRejected) {
+		t.Errorf("expected ErrTurnstileRejected, got %v", err)
+	}
+}
+
+func TestLoginAnonymous_NoSecretKey(t *testing.T) {
+	svc, _ := NewAuthService(
+		&mockSpotifyOAuth{},
+		&mockUserUpserter{}, "jwt-secret", "",
+	)
+
+	_, err := svc.LoginAnonymous(context.Background(), "token")
+	if err == nil {
+		t.Fatal("expected error for missing secret key")
+	}
+}
+
+func TestNewAuthService_NilSpotify(t *testing.T) {
+	_, err := NewAuthService(nil, &mockUserUpserter{}, "secret", "")
+	if err == nil {
+		t.Error("expected error for nil spotify")
+	}
+}
+
+func TestNewAuthService_NilUsers(t *testing.T) {
+	_, err := NewAuthService(&mockSpotifyOAuth{}, nil, "secret", "")
+	if err == nil {
+		t.Error("expected error for nil users")
+	}
+}

--- a/backend/internal/service/explore.go
+++ b/backend/internal/service/explore.go
@@ -1,0 +1,46 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/pseudo/vibe-seeker/backend/internal/store"
+)
+
+// TagReader provides read access to global tag data.
+type TagReader interface {
+	GetTopTags(ctx context.Context, limit int) ([]store.TagPrevalence, error)
+	GetRelatedTags(ctx context.Context, tag string, limit int) ([]store.TagRelation, error)
+}
+
+// ExploreService provides tag exploration capabilities for the explore graph.
+type ExploreService struct {
+	tags TagReader
+}
+
+// NewExploreService creates an ExploreService.
+func NewExploreService(tags TagReader) (*ExploreService, error) {
+	if tags == nil {
+		return nil, errors.New("explore service: nil tag reader")
+	}
+	return &ExploreService{tags: tags}, nil
+}
+
+// GetTopVibes returns the most prevalent vibes across all cached artist data.
+func (s *ExploreService) GetTopVibes(ctx context.Context, limit int) ([]store.TagPrevalence, error) {
+	tags, err := s.tags.GetTopTags(ctx, limit)
+	if err != nil {
+		return nil, fmt.Errorf("querying top tags: %w", err)
+	}
+	return tags, nil
+}
+
+// GetRelatedVibes returns vibes related to a given tag by artist co-occurrence.
+func (s *ExploreService) GetRelatedVibes(ctx context.Context, tag string, limit int) ([]store.TagRelation, error) {
+	related, err := s.tags.GetRelatedTags(ctx, tag, limit)
+	if err != nil {
+		return nil, fmt.Errorf("querying related tags: %w", err)
+	}
+	return related, nil
+}

--- a/backend/internal/service/explore_test.go
+++ b/backend/internal/service/explore_test.go
@@ -1,0 +1,82 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/pseudo/vibe-seeker/backend/internal/store"
+)
+
+type mockTagReader struct {
+	topTags     []store.TagPrevalence
+	relatedTags []store.TagRelation
+	topErr      error
+	relatedErr  error
+}
+
+func (m *mockTagReader) GetTopTags(_ context.Context, _ int) ([]store.TagPrevalence, error) {
+	return m.topTags, m.topErr
+}
+
+func (m *mockTagReader) GetRelatedTags(_ context.Context, _ string, _ int) ([]store.TagRelation, error) {
+	return m.relatedTags, m.relatedErr
+}
+
+func TestExploreService_GetTopVibes(t *testing.T) {
+	svc, _ := NewExploreService(&mockTagReader{
+		topTags: []store.TagPrevalence{
+			{Tag: "rock", Prevalence: 1.0},
+			{Tag: "indie", Prevalence: 0.85},
+		},
+	})
+
+	tags, err := svc.GetTopVibes(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("GetTopVibes: %v", err)
+	}
+	if len(tags) != 2 {
+		t.Errorf("expected 2 tags, got %d", len(tags))
+	}
+}
+
+func TestExploreService_GetTopVibes_Error(t *testing.T) {
+	svc, _ := NewExploreService(&mockTagReader{topErr: errors.New("db error")})
+
+	_, err := svc.GetTopVibes(context.Background(), 10)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestExploreService_GetRelatedVibes(t *testing.T) {
+	svc, _ := NewExploreService(&mockTagReader{
+		relatedTags: []store.TagRelation{
+			{Tag: "indie", Strength: 1.0},
+		},
+	})
+
+	related, err := svc.GetRelatedVibes(context.Background(), "rock", 8)
+	if err != nil {
+		t.Fatalf("GetRelatedVibes: %v", err)
+	}
+	if len(related) != 1 {
+		t.Errorf("expected 1 related tag, got %d", len(related))
+	}
+}
+
+func TestExploreService_GetRelatedVibes_Error(t *testing.T) {
+	svc, _ := NewExploreService(&mockTagReader{relatedErr: errors.New("db error")})
+
+	_, err := svc.GetRelatedVibes(context.Background(), "rock", 8)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestNewExploreService_NilTagReader(t *testing.T) {
+	_, err := NewExploreService(nil)
+	if err == nil {
+		t.Error("expected error for nil tag reader")
+	}
+}

--- a/backend/internal/service/tag_enricher.go
+++ b/backend/internal/service/tag_enricher.go
@@ -1,0 +1,120 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/pseudo/vibe-seeker/backend/internal/lastfm"
+	"github.com/pseudo/vibe-seeker/backend/internal/observability"
+	"github.com/pseudo/vibe-seeker/backend/internal/ratelimit"
+	"github.com/pseudo/vibe-seeker/backend/internal/store"
+)
+
+// LastFMClient fetches artist tags from the Last.fm API.
+type LastFMClient interface {
+	FetchArtistTags(ctx context.Context, artistName string) ([]lastfm.Tag, error)
+}
+
+// TagCache provides read-through caching for artist tags.
+type TagCache interface {
+	GetCachedTags(ctx context.Context, artistName string) ([]lastfm.Tag, error)
+	UpsertArtistTags(ctx context.Context, artistName string, tags []lastfm.Tag) error
+	UpsertArtistTagsWithSource(ctx context.Context, artistName string, tags []lastfm.Tag, source string) error
+	GetClassificationsForArtist(ctx context.Context, artistName string) ([]lastfm.Tag, error)
+}
+
+// TagEnricher resolves artist tags using a cache-first strategy:
+// DB cache → Last.fm API → Ticketmaster classifications fallback.
+type TagEnricher struct {
+	lastFM   LastFMClient
+	tagCache TagCache
+}
+
+// EnrichResult holds the output of an artist tag enrichment pass.
+type EnrichResult struct {
+	ArtistTags map[string][]lastfm.Tag
+	CacheHits  int
+}
+
+// NewTagEnricher creates a TagEnricher with the given Last.fm client and cache.
+func NewTagEnricher(lfm LastFMClient, cache TagCache) *TagEnricher {
+	return &TagEnricher{lastFM: lfm, tagCache: cache}
+}
+
+// Enrich fetches tags for each artist name using the cache-first strategy.
+// It rate-limits Last.fm API calls at the given interval.
+func (e *TagEnricher) Enrich(ctx context.Context, artistNames []string, rateLimit time.Duration) EnrichResult {
+	log := observability.Logger(ctx)
+
+	limiter := ratelimit.NewLimiter(rateLimit)
+	defer limiter.Stop()
+
+	result := EnrichResult{ArtistTags: make(map[string][]lastfm.Tag)}
+
+	for _, name := range artistNames {
+		if ctx.Err() != nil {
+			log.Error("tag enrichment timed out", "fetched", len(result.ArtistTags), "total", len(artistNames))
+			break
+		}
+
+		tags, fromCache := e.enrichOne(ctx, log, limiter, name)
+		if tags != nil {
+			result.ArtistTags[name] = tags
+			if fromCache {
+				result.CacheHits++
+			}
+		}
+	}
+
+	log.Info("tag enrichment complete", "total", len(artistNames), "cache_hits", result.CacheHits, "api_calls", len(artistNames)-result.CacheHits)
+	return result
+}
+
+// enrichOne resolves tags for a single artist: cache → Last.fm → TM fallback.
+// Returns the tags and whether they came from cache.
+func (e *TagEnricher) enrichOne(ctx context.Context, log *slog.Logger, limiter *ratelimit.Limiter, name string) ([]lastfm.Tag, bool) {
+	// 1. Check cache.
+	cached, err := e.tagCache.GetCachedTags(ctx, name)
+	if err != nil {
+		log.Error("cache lookup failed", "artist", name, "error", err)
+	}
+	if cached != nil {
+		return cached, true
+	}
+
+	// 2. Cache miss — fetch from Last.fm (rate-limited).
+	if err := limiter.Wait(ctx); err != nil {
+		log.Error("tag fetch timed out during rate-limit wait", "error", err)
+		return nil, false
+	}
+	tags, err := e.lastFM.FetchArtistTags(ctx, name)
+	if err != nil {
+		log.Error("failed to fetch lastfm tags", "artist", name, "error", err)
+		return nil, false
+	}
+
+	if len(tags) > 0 {
+		if cacheErr := e.tagCache.UpsertArtistTags(ctx, name, tags); cacheErr != nil {
+			log.Error("failed to cache lastfm tags", "artist", name, "error", cacheErr)
+		}
+		return tags, false
+	}
+
+	// 3. Last.fm miss — fall back to Ticketmaster classifications.
+	tmTags, tmErr := e.tagCache.GetClassificationsForArtist(ctx, name)
+	if tmErr != nil {
+		log.Error("failed to get TM classifications", "artist", name, "error", tmErr)
+		return nil, false
+	}
+	if len(tmTags) > 0 {
+		log.Info("using ticketmaster classifications as fallback", "artist", name, "tags", len(tmTags))
+		if cacheErr := e.tagCache.UpsertArtistTagsWithSource(ctx, name, tmTags, store.TagSourceTicketmaster); cacheErr != nil {
+			log.Error("failed to cache TM tags", "artist", name, "error", cacheErr)
+		}
+		return tmTags, false
+	}
+
+	log.Info("no tag data available for artist", "artist", name)
+	return nil, false
+}

--- a/backend/internal/service/tag_enricher.go
+++ b/backend/internal/service/tag_enricher.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -38,8 +39,14 @@ type EnrichResult struct {
 }
 
 // NewTagEnricher creates a TagEnricher with the given Last.fm client and cache.
-func NewTagEnricher(lfm LastFMClient, cache TagCache) *TagEnricher {
-	return &TagEnricher{lastFM: lfm, tagCache: cache}
+func NewTagEnricher(lfm LastFMClient, cache TagCache) (*TagEnricher, error) {
+	if lfm == nil {
+		return nil, errors.New("tag enricher: nil lastfm client")
+	}
+	if cache == nil {
+		return nil, errors.New("tag enricher: nil tag cache")
+	}
+	return &TagEnricher{lastFM: lfm, tagCache: cache}, nil
 }
 
 // Enrich fetches tags for each artist name using the cache-first strategy.

--- a/backend/internal/service/tag_enricher_test.go
+++ b/backend/internal/service/tag_enricher_test.go
@@ -1,0 +1,163 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/pseudo/vibe-seeker/backend/internal/lastfm"
+)
+
+type mockLastFM struct {
+	tags map[string][]lastfm.Tag
+	err  error
+}
+
+func (m *mockLastFM) FetchArtistTags(_ context.Context, artistName string) ([]lastfm.Tag, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.tags[artistName], nil
+}
+
+type mockTagCache struct {
+	cached          map[string][]lastfm.Tag
+	classifications map[string][]lastfm.Tag
+	upserted        map[string][]lastfm.Tag
+}
+
+func newMockTagCache() *mockTagCache {
+	return &mockTagCache{
+		cached:          make(map[string][]lastfm.Tag),
+		classifications: make(map[string][]lastfm.Tag),
+		upserted:        make(map[string][]lastfm.Tag),
+	}
+}
+
+func (m *mockTagCache) GetCachedTags(_ context.Context, artistName string) ([]lastfm.Tag, error) {
+	if tags, ok := m.cached[artistName]; ok {
+		return tags, nil
+	}
+	return nil, nil
+}
+
+func (m *mockTagCache) UpsertArtistTags(_ context.Context, artistName string, tags []lastfm.Tag) error {
+	m.upserted[artistName] = tags
+	return nil
+}
+
+func (m *mockTagCache) UpsertArtistTagsWithSource(_ context.Context, artistName string, tags []lastfm.Tag, _ string) error {
+	m.upserted[artistName] = tags
+	return nil
+}
+
+func (m *mockTagCache) GetClassificationsForArtist(_ context.Context, artistName string) ([]lastfm.Tag, error) {
+	return m.classifications[artistName], nil
+}
+
+func TestEnrich_CacheHit(t *testing.T) {
+	cache := newMockTagCache()
+	cache.cached["artist one"] = []lastfm.Tag{{Name: "rock", Count: 100}}
+
+	enricher := NewTagEnricher(&mockLastFM{}, cache)
+	result := enricher.Enrich(context.Background(), []string{"artist one"}, 10*time.Millisecond)
+
+	if result.CacheHits != 1 {
+		t.Errorf("expected 1 cache hit, got %d", result.CacheHits)
+	}
+	if len(result.ArtistTags["artist one"]) != 1 {
+		t.Error("expected tags for 'artist one'")
+	}
+}
+
+func TestEnrich_LastFMFetch(t *testing.T) {
+	lfm := &mockLastFM{
+		tags: map[string][]lastfm.Tag{
+			"artist two": {{Name: "indie", Count: 90}},
+		},
+	}
+	cache := newMockTagCache()
+
+	enricher := NewTagEnricher(lfm, cache)
+	result := enricher.Enrich(context.Background(), []string{"artist two"}, 10*time.Millisecond)
+
+	if result.CacheHits != 0 {
+		t.Errorf("expected 0 cache hits, got %d", result.CacheHits)
+	}
+	if len(result.ArtistTags["artist two"]) != 1 {
+		t.Error("expected tags for 'artist two'")
+	}
+	// Should have been cached.
+	if len(cache.upserted["artist two"]) != 1 {
+		t.Error("expected tags to be cached")
+	}
+}
+
+func TestEnrich_TMFallback(t *testing.T) {
+	lfm := &mockLastFM{tags: map[string][]lastfm.Tag{}} // Last.fm returns empty
+	cache := newMockTagCache()
+	cache.classifications["artist three"] = []lastfm.Tag{{Name: "pop", Count: 80}}
+
+	enricher := NewTagEnricher(lfm, cache)
+	result := enricher.Enrich(context.Background(), []string{"artist three"}, 10*time.Millisecond)
+
+	if len(result.ArtistTags["artist three"]) != 1 {
+		t.Error("expected TM fallback tags for 'artist three'")
+	}
+	if result.ArtistTags["artist three"][0].Name != "pop" {
+		t.Errorf("expected 'pop' tag, got %q", result.ArtistTags["artist three"][0].Name)
+	}
+}
+
+func TestEnrich_LastFMError(t *testing.T) {
+	lfm := &mockLastFM{err: errors.New("api error")}
+	cache := newMockTagCache()
+
+	enricher := NewTagEnricher(lfm, cache)
+	result := enricher.Enrich(context.Background(), []string{"artist four"}, 10*time.Millisecond)
+
+	if len(result.ArtistTags) != 0 {
+		t.Errorf("expected no tags on error, got %d", len(result.ArtistTags))
+	}
+}
+
+func TestEnrich_ContextCanceled(t *testing.T) {
+	lfm := &mockLastFM{tags: map[string][]lastfm.Tag{
+		"a": {{Name: "rock", Count: 100}},
+		"b": {{Name: "jazz", Count: 90}},
+	}}
+	cache := newMockTagCache()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	enricher := NewTagEnricher(lfm, cache)
+	result := enricher.Enrich(ctx, []string{"a", "b"}, 10*time.Millisecond)
+
+	// With a canceled context, should not fetch any tags.
+	if len(result.ArtistTags) != 0 {
+		t.Errorf("expected no tags with canceled context, got %d", len(result.ArtistTags))
+	}
+}
+
+func TestEnrich_MixedCacheAndFetch(t *testing.T) {
+	cache := newMockTagCache()
+	cache.cached["cached-artist"] = []lastfm.Tag{{Name: "rock", Count: 100}}
+
+	lfm := &mockLastFM{
+		tags: map[string][]lastfm.Tag{
+			"new-artist": {{Name: "electronic", Count: 85}},
+		},
+	}
+
+	enricher := NewTagEnricher(lfm, cache)
+	result := enricher.Enrich(context.Background(), []string{"cached-artist", "new-artist"}, 10*time.Millisecond)
+
+	if result.CacheHits != 1 {
+		t.Errorf("expected 1 cache hit, got %d", result.CacheHits)
+	}
+	if len(result.ArtistTags) != 2 {
+		t.Errorf("expected 2 artist tags, got %d", len(result.ArtistTags))
+	}
+}

--- a/backend/internal/service/tag_enricher_test.go
+++ b/backend/internal/service/tag_enricher_test.go
@@ -60,7 +60,7 @@ func TestEnrich_CacheHit(t *testing.T) {
 	cache := newMockTagCache()
 	cache.cached["artist one"] = []lastfm.Tag{{Name: "rock", Count: 100}}
 
-	enricher := NewTagEnricher(&mockLastFM{}, cache)
+	enricher, _ := NewTagEnricher(&mockLastFM{}, cache)
 	result := enricher.Enrich(context.Background(), []string{"artist one"}, 10*time.Millisecond)
 
 	if result.CacheHits != 1 {
@@ -79,7 +79,7 @@ func TestEnrich_LastFMFetch(t *testing.T) {
 	}
 	cache := newMockTagCache()
 
-	enricher := NewTagEnricher(lfm, cache)
+	enricher, _ := NewTagEnricher(lfm, cache)
 	result := enricher.Enrich(context.Background(), []string{"artist two"}, 10*time.Millisecond)
 
 	if result.CacheHits != 0 {
@@ -99,7 +99,7 @@ func TestEnrich_TMFallback(t *testing.T) {
 	cache := newMockTagCache()
 	cache.classifications["artist three"] = []lastfm.Tag{{Name: "pop", Count: 80}}
 
-	enricher := NewTagEnricher(lfm, cache)
+	enricher, _ := NewTagEnricher(lfm, cache)
 	result := enricher.Enrich(context.Background(), []string{"artist three"}, 10*time.Millisecond)
 
 	if len(result.ArtistTags["artist three"]) != 1 {
@@ -114,7 +114,7 @@ func TestEnrich_LastFMError(t *testing.T) {
 	lfm := &mockLastFM{err: errors.New("api error")}
 	cache := newMockTagCache()
 
-	enricher := NewTagEnricher(lfm, cache)
+	enricher, _ := NewTagEnricher(lfm, cache)
 	result := enricher.Enrich(context.Background(), []string{"artist four"}, 10*time.Millisecond)
 
 	if len(result.ArtistTags) != 0 {
@@ -132,7 +132,7 @@ func TestEnrich_ContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
 
-	enricher := NewTagEnricher(lfm, cache)
+	enricher, _ := NewTagEnricher(lfm, cache)
 	result := enricher.Enrich(ctx, []string{"a", "b"}, 10*time.Millisecond)
 
 	// With a canceled context, should not fetch any tags.
@@ -151,7 +151,7 @@ func TestEnrich_MixedCacheAndFetch(t *testing.T) {
 		},
 	}
 
-	enricher := NewTagEnricher(lfm, cache)
+	enricher, _ := NewTagEnricher(lfm, cache)
 	result := enricher.Enrich(context.Background(), []string{"cached-artist", "new-artist"}, 10*time.Millisecond)
 
 	if result.CacheHits != 1 {
@@ -159,5 +159,26 @@ func TestEnrich_MixedCacheAndFetch(t *testing.T) {
 	}
 	if len(result.ArtistTags) != 2 {
 		t.Errorf("expected 2 artist tags, got %d", len(result.ArtistTags))
+	}
+}
+
+func TestNewTagEnricher_NilDeps(t *testing.T) {
+	cache := newMockTagCache()
+	lfm := &mockLastFM{}
+
+	tests := []struct {
+		name  string
+		lfm   LastFMClient
+		cache TagCache
+	}{
+		{"nil lastfm", nil, cache},
+		{"nil cache", lfm, nil},
+	}
+
+	for _, tt := range tests {
+		_, err := NewTagEnricher(tt.lfm, tt.cache)
+		if err == nil {
+			t.Errorf("%s: expected error", tt.name)
+		}
 	}
 }

--- a/backend/internal/service/venue.go
+++ b/backend/internal/service/venue.go
@@ -1,0 +1,480 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/pseudo/vibe-seeker/backend/internal/configuration"
+	"github.com/pseudo/vibe-seeker/backend/internal/observability"
+	"github.com/pseudo/vibe-seeker/backend/internal/store"
+	"github.com/pseudo/vibe-seeker/backend/internal/ticketmaster"
+	"github.com/pseudo/vibe-seeker/backend/internal/vibes"
+)
+
+// TicketmasterClient provides the Ticketmaster methods needed for venue syncing.
+type TicketmasterClient interface {
+	SearchVenues(ctx context.Context, opts ticketmaster.VenueSearchOptions) ([]ticketmaster.Venue, error)
+	SearchEvents(ctx context.Context, opts ticketmaster.EventSearchOptions) ([]ticketmaster.Event, error)
+}
+
+// VenueWriter persists venue, show, and artist data.
+type VenueWriter interface {
+	UpsertVenues(ctx context.Context, venues []store.Venue) error
+	UpsertShows(ctx context.Context, shows []store.Show) error
+	UpsertArtists(ctx context.Context, artists []store.Artist) error
+	UpsertShowArtists(ctx context.Context, links []store.ShowArtist) error
+	UpsertShowClassifications(ctx context.Context, classifications []store.ShowClassification) error
+	GetVenueFetchedAt(ctx context.Context, dataSource string) (*time.Time, error)
+}
+
+// VenueReader retrieves venue data.
+type VenueReader interface {
+	GetVenues(ctx context.Context) ([]store.Venue, error)
+	GetShowsForVenues(ctx context.Context, venueIDs []string) (map[string][]store.ShowSummary, error)
+	GetAllVenueArtists(ctx context.Context, venueIDs []string) (map[string][]store.VenueArtist, error)
+	GetAllVenueVibes(ctx context.Context, venueIDs []string) (map[string]map[string]float32, error)
+}
+
+// VenueVibeWriter persists venue vibe profiles.
+type VenueVibeWriter interface {
+	UpsertVenueVibes(ctx context.Context, venueID string, vibeWeights map[string]float32) error
+}
+
+// nycSearchTiles covers the NYC metro area with overlapping 3-mile-radius
+// circles, each staying under Ticketmaster's 1,000-result pagination limit.
+var nycSearchTiles = []ticketmaster.VenueSearchOptions{
+	{GeoPoint: "40.7128,-74.0060", Radius: "3"},  // Lower/Midtown Manhattan
+	{GeoPoint: "40.8100,-73.9500", Radius: "3"},  // Upper Manhattan / Harlem
+	{GeoPoint: "40.6782,-73.9442", Radius: "3"},  // Brooklyn
+	{GeoPoint: "40.7282,-73.7949", Radius: "3"},  // Queens
+	{GeoPoint: "40.8448,-73.8648", Radius: "3"},  // Bronx
+	{GeoPoint: "40.7178,-74.0431", Radius: "3"},  // Hoboken / Jersey City
+}
+
+// VenueSyncResult contains the outcome of a venue sync operation.
+type VenueSyncResult struct {
+	Synced        bool
+	Skipped       bool
+	LastFetched   *time.Time
+	VenueCount    int
+	ShowCount     int
+	VibesComputed int
+}
+
+// VenueWithDetails holds a venue plus its upcoming shows and vibe profile.
+type VenueWithDetails struct {
+	store.Venue
+	Shows []store.ShowSummary    `json:"shows"`
+	Vibes map[string]float32     `json:"vibes,omitempty"`
+}
+
+// VenueService orchestrates venue and event ingestion from Ticketmaster,
+// venue vibe computation, and venue listing.
+type VenueService struct {
+	ticketmaster TicketmasterClient
+	venues       VenueWriter
+	venueReader  VenueReader
+	venueVibes   VenueVibeWriter
+	tagEnricher  *TagEnricher
+}
+
+// NewVenueService creates a VenueService.
+func NewVenueService(tm TicketmasterClient, venues interface {
+	VenueWriter
+	VenueReader
+	VenueVibeWriter
+}, enricher *TagEnricher) (*VenueService, error) {
+	if tm == nil {
+		return nil, errors.New("venue service: nil ticketmaster client")
+	}
+	if venues == nil {
+		return nil, errors.New("venue service: nil venue store")
+	}
+	if enricher == nil {
+		return nil, errors.New("venue service: nil tag enricher")
+	}
+	return &VenueService{
+		ticketmaster: tm,
+		venues:       venues,
+		venueReader:  venues,
+		venueVibes:   venues,
+		tagEnricher:  enricher,
+	}, nil
+}
+
+// SyncVenues fetches NYC venues and upcoming events from Ticketmaster,
+// persists them, and computes venue vibes.
+func (s *VenueService) SyncVenues(ctx context.Context) (*VenueSyncResult, error) {
+	log := observability.Logger(ctx)
+
+	// TTL check: skip if data is fresh.
+	lastFetched, err := s.venues.GetVenueFetchedAt(ctx, configuration.DataSourceTicketmaster)
+	if err != nil {
+		log.Error("failed to check venue TTL, proceeding with sync", "error", err)
+	}
+	if err == nil && lastFetched != nil && time.Since(*lastFetched) < configuration.VenueCacheTTL {
+		return &VenueSyncResult{Skipped: true, LastFetched: lastFetched}, nil
+	}
+
+	syncCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), configuration.VenueSyncTimeout)
+	defer cancel()
+
+	// 1. Fetch venues from tiled search regions, deduplicating by TM ID.
+	seen := make(map[string]bool)
+	var tmVenues []ticketmaster.Venue
+	for _, tile := range nycSearchTiles {
+		if syncCtx.Err() != nil {
+			log.Error("venue fetch timed out", "fetched", len(tmVenues))
+			break
+		}
+		tileVenues, err := s.ticketmaster.SearchVenues(syncCtx, tile)
+		if err != nil {
+			log.Error("failed to fetch ticketmaster venues", "tile", tile.GeoPoint, "error", err)
+			continue
+		}
+		for _, v := range tileVenues {
+			if !seen[v.ID] {
+				seen[v.ID] = true
+				tmVenues = append(tmVenues, v)
+			}
+		}
+		log.Info("tile fetched", "center", tile.GeoPoint, "raw", len(tileVenues), "unique_total", len(tmVenues))
+	}
+
+	storeVenues := MapVenues(tmVenues)
+	dbCtx := context.WithoutCancel(ctx)
+	if err := s.venues.UpsertVenues(dbCtx, storeVenues); err != nil {
+		return nil, fmt.Errorf("persisting venues: %w", err)
+	}
+	log.Info("venues synced", "count", len(storeVenues))
+
+	// 2. Fetch events per venue with adaptive rate limiting.
+	now := time.Now().UTC().Format("2006-01-02T15:04:05Z")
+
+	var shows []store.Show
+	var artists []store.Artist
+	var showArtists []store.ShowArtist
+	var classifications []store.ShowClassification
+	seenArtists := make(map[string]bool)
+
+	queue := make([]store.Venue, len(storeVenues))
+	copy(queue, storeVenues)
+	delay := configuration.TicketmasterRateLimit
+	processed := 0
+
+	for len(queue) > 0 {
+		if syncCtx.Err() != nil {
+			log.Error("event fetch timed out", "processed", processed, "remaining", len(queue))
+			break
+		}
+
+		sv := queue[0]
+		queue = queue[1:]
+
+		log.Info("fetching events", "venue", sv.Name, "processed", processed, "remaining", len(queue), "delay", delay)
+		select {
+		case <-syncCtx.Done():
+			log.Error("event fetch timed out during delay", "processed", processed, "remaining", len(queue))
+			queue = nil
+			continue
+		case <-time.After(delay):
+		}
+		tmEvents, err := s.ticketmaster.SearchEvents(syncCtx, ticketmaster.EventSearchOptions{
+			VenueID:       sv.TMID,
+			StartDateTime: now,
+		})
+		if errors.Is(err, ticketmaster.ErrRateLimited) {
+			queue = append(queue, sv)
+			delay += 1 * time.Second
+			log.Info("rate limited, backing off", "delay", delay, "remaining", len(queue))
+			continue
+		}
+		if err != nil {
+			log.Error("failed to fetch events for venue", "venue", sv.Name, "error", err)
+			continue
+		}
+
+		// Successful request — reduce delay toward floor.
+		if delay > configuration.TicketmasterRateLimit {
+			delay -= 1 * time.Second
+			if delay < configuration.TicketmasterRateLimit {
+				delay = configuration.TicketmasterRateLimit
+			}
+		}
+		processed++
+		log.Info("events fetched", "venue", sv.Name, "events", len(tmEvents), "shows_total", len(shows)+len(tmEvents))
+
+		for _, ev := range tmEvents {
+			showID := configuration.IDPrefixTicketmaster + ev.ID
+			showDate, err := time.Parse(time.RFC3339, ev.Dates.Start.DateTime)
+			if err != nil {
+				showDate, err = time.Parse("2006-01-02", ev.Dates.Start.LocalDate)
+				if err != nil {
+					log.Error("skipping event with unparseable date", "event", ev.Name, "dateTime", ev.Dates.Start.DateTime)
+					continue
+				}
+			}
+
+			var priceMin, priceMax float64
+			if len(ev.PriceRanges) > 0 {
+				priceMin = ev.PriceRanges[0].Min
+				priceMax = ev.PriceRanges[0].Max
+			}
+
+			shows = append(shows, store.Show{
+				ID:         showID,
+				Name:       ev.Name,
+				VenueID:    sv.ID,
+				ShowDate:   showDate,
+				TicketURL:  ev.URL,
+				PriceMin:   priceMin,
+				PriceMax:   priceMax,
+				Status:     ev.Dates.Status.Code,
+				DataSource: configuration.DataSourceTicketmaster,
+			})
+
+			for i, attr := range ev.Embedded.Attractions {
+				artistID := store.Slugify(attr.Name)
+				if artistID == "" {
+					continue
+				}
+
+				if !seenArtists[artistID] {
+					var imgURL string
+					if len(attr.Images) > 0 {
+						imgURL = attr.Images[0].URL
+					}
+					artists = append(artists, store.Artist{
+						ID:       artistID,
+						Name:     attr.Name,
+						ImageURL: imgURL,
+					})
+					seenArtists[artistID] = true
+				}
+
+				showArtists = append(showArtists, store.ShowArtist{
+					ShowID:       showID,
+					ArtistID:     artistID,
+					BillingOrder: i + 1,
+				})
+			}
+
+			for _, cl := range ev.Classifications {
+				if cl.Segment.Name == "" && cl.Genre.Name == "" && cl.SubGenre.Name == "" {
+					continue
+				}
+				classifications = append(classifications, store.ShowClassification{
+					ShowID:   showID,
+					Segment:  cl.Segment.Name,
+					Genre:    cl.Genre.Name,
+					SubGenre: cl.SubGenre.Name,
+				})
+			}
+		}
+	}
+
+	// 3. Persist everything.
+	if len(shows) > 0 {
+		if err := s.venues.UpsertShows(dbCtx, shows); err != nil {
+			return nil, fmt.Errorf("persisting shows: %w", err)
+		}
+	}
+	if len(artists) > 0 {
+		if err := s.venues.UpsertArtists(dbCtx, artists); err != nil {
+			return nil, fmt.Errorf("persisting artists: %w", err)
+		}
+	}
+	if len(showArtists) > 0 {
+		if err := s.venues.UpsertShowArtists(dbCtx, showArtists); err != nil {
+			return nil, fmt.Errorf("persisting show-artist links: %w", err)
+		}
+	}
+	if len(classifications) > 0 {
+		if err := s.venues.UpsertShowClassifications(dbCtx, classifications); err != nil {
+			return nil, fmt.Errorf("persisting show classifications: %w", err)
+		}
+	}
+
+	log.Info("venue sync complete", "venues", len(storeVenues), "shows", len(shows), "artists", len(artists))
+
+	// 4. Compute venue vibes from show artists + tags.
+	vibesComputed := s.computeVenueVibes(syncCtx, ctx, storeVenues)
+
+	return &VenueSyncResult{
+		Synced:        true,
+		VenueCount:    len(storeVenues),
+		ShowCount:     len(shows),
+		VibesComputed: vibesComputed,
+	}, nil
+}
+
+// SyncVenueVibes recomputes vibe profiles for all venues without re-fetching
+// from Ticketmaster.
+func (s *VenueService) SyncVenueVibes(ctx context.Context) (int, error) {
+	venues, err := s.venueReader.GetVenues(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("reading venues: %w", err)
+	}
+
+	syncCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), configuration.VenueSyncTimeout)
+	defer cancel()
+
+	computed := s.computeVenueVibes(syncCtx, ctx, venues)
+	return computed, nil
+}
+
+// GetVenues returns all venues that have shows, with their upcoming shows
+// and vibe profiles attached.
+func (s *VenueService) GetVenues(ctx context.Context) ([]VenueWithDetails, error) {
+	venues, err := s.venueReader.GetVenues(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("reading venues: %w", err)
+	}
+
+	log := observability.Logger(ctx)
+
+	// Only include venues with shows.
+	var venueIDs []string
+	venueMap := make(map[string]store.Venue)
+	for _, v := range venues {
+		if v.ShowsTracked == 0 {
+			continue
+		}
+		venueIDs = append(venueIDs, v.ID)
+		venueMap[v.ID] = v
+	}
+
+	showsByVenue := make(map[string][]store.ShowSummary)
+	vibesByVenue := make(map[string]map[string]float32)
+	if len(venueIDs) > 0 {
+		var err error
+		showsByVenue, err = s.venueReader.GetShowsForVenues(ctx, venueIDs)
+		if err != nil {
+			log.Error("failed to read shows for venues", "error", err)
+		}
+		vibesByVenue, err = s.venueReader.GetAllVenueVibes(ctx, venueIDs)
+		if err != nil {
+			log.Error("failed to read venue vibes", "error", err)
+		}
+	}
+
+	var result []VenueWithDetails
+	for _, id := range venueIDs {
+		result = append(result, VenueWithDetails{
+			Venue: venueMap[id],
+			Shows: showsByVenue[id],
+			Vibes: vibesByVenue[id],
+		})
+	}
+
+	return result, nil
+}
+
+// computeVenueVibes computes vibe profiles for all venues with shows.
+// Returns the number of venues with vibes computed.
+func (s *VenueService) computeVenueVibes(syncCtx, parentCtx context.Context, venues []store.Venue) int {
+	log := observability.Logger(parentCtx)
+
+	var venueIDs []string
+	for _, v := range venues {
+		if v.ShowsTracked > 0 {
+			venueIDs = append(venueIDs, v.ID)
+		}
+	}
+	if len(venueIDs) == 0 {
+		return 0
+	}
+
+	// Get all artists for all venues in one query.
+	allArtists, err := s.venueReader.GetAllVenueArtists(syncCtx, venueIDs)
+	if err != nil {
+		log.Error("failed to get venue artists for vibe computation", "error", err)
+		return 0
+	}
+
+	// Collect unique artist names across all venues.
+	uniqueArtists := make(map[string]bool)
+	for _, artists := range allArtists {
+		for _, a := range artists {
+			uniqueArtists[strings.ToLower(a.ArtistName)] = true
+		}
+	}
+
+	uniqueNames := make([]string, 0, len(uniqueArtists))
+	for name := range uniqueArtists {
+		uniqueNames = append(uniqueNames, name)
+	}
+
+	enrichResult := s.tagEnricher.Enrich(syncCtx, uniqueNames, configuration.LastFMRateLimit)
+
+	// Compute vibes per venue.
+	dbCtx := context.WithoutCancel(parentCtx)
+	computed := 0
+	for _, venueID := range venueIDs {
+		venueArtists := allArtists[venueID]
+		if len(venueArtists) == 0 {
+			continue
+		}
+
+		va := make([]vibes.VenueArtist, len(venueArtists))
+		for i, a := range venueArtists {
+			va[i] = vibes.VenueArtist{ArtistName: a.ArtistName, ShowDate: a.ShowDate}
+		}
+
+		venueVibe := vibes.ComputeVenueVibe(va, enrichResult.ArtistTags)
+		if len(venueVibe) == 0 {
+			continue
+		}
+
+		if err := s.venueVibes.UpsertVenueVibes(dbCtx, venueID, venueVibe); err != nil {
+			log.Error("failed to persist venue vibes", "venue", venueID, "error", err)
+			continue
+		}
+		computed++
+	}
+
+	log.Info("venue vibes computed", "computed", computed, "total_venues", len(venueIDs))
+	return computed
+}
+
+// MapVenues converts Ticketmaster venue data to store.Venue format,
+// filtering out non-US venues and venues without coordinates.
+func MapVenues(tmVenues []ticketmaster.Venue) []store.Venue {
+	result := make([]store.Venue, 0, len(tmVenues))
+	for _, v := range tmVenues {
+		if v.Country.CountryCode != "" && v.Country.CountryCode != "US" {
+			continue
+		}
+		lat := v.Lat()
+		lng := v.Lng()
+		if lat == 0 && lng == 0 {
+			continue
+		}
+
+		var imgURL string
+		if len(v.Images) > 0 {
+			imgURL = v.Images[0].URL
+		}
+
+		result = append(result, store.Venue{
+			ID:            configuration.IDPrefixTicketmaster + v.ID,
+			Name:          v.Name,
+			Latitude:      lat,
+			Longitude:     lng,
+			Address:       v.Address.Line1,
+			City:          v.City.Name,
+			State:         v.State.StateCode,
+			ImageURL:      imgURL,
+			BoxOfficeInfo: v.BoxOfficeInfo,
+			ParkingDetail: v.ParkingDetail,
+			GeneralInfo:   v.GeneralInfo,
+			Ada:           v.Ada,
+			DataSource:    configuration.DataSourceTicketmaster,
+			TMID:          v.ID,
+		})
+	}
+	return result
+}

--- a/backend/internal/service/venue_test.go
+++ b/backend/internal/service/venue_test.go
@@ -1,0 +1,252 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pseudo/vibe-seeker/backend/internal/lastfm"
+	"github.com/pseudo/vibe-seeker/backend/internal/store"
+	"github.com/pseudo/vibe-seeker/backend/internal/ticketmaster"
+)
+
+type mockTicketmaster struct {
+	venues []ticketmaster.Venue
+	events []ticketmaster.Event
+	err    error
+}
+
+func (m *mockTicketmaster) SearchVenues(_ context.Context, _ ticketmaster.VenueSearchOptions) ([]ticketmaster.Venue, error) {
+	return m.venues, m.err
+}
+
+func (m *mockTicketmaster) SearchEvents(_ context.Context, _ ticketmaster.EventSearchOptions) ([]ticketmaster.Event, error) {
+	return m.events, m.err
+}
+
+type mockVenueStore2 struct {
+	upsertVenuesCalled          bool
+	upsertShowsCalled           bool
+	upsertArtistsCalled         bool
+	upsertShowArtistsCalled     bool
+	upsertClassificationsCalled bool
+	upsertVibesCalled           bool
+	venues                      []store.Venue
+	fetchedAt                   *time.Time
+	showsByVenue                map[string][]store.ShowSummary
+	artistsByVenue              map[string][]store.VenueArtist
+	vibesByVenue                map[string]map[string]float32
+	err                         error
+}
+
+func (m *mockVenueStore2) UpsertVenues(_ context.Context, _ []store.Venue) error {
+	m.upsertVenuesCalled = true
+	return m.err
+}
+func (m *mockVenueStore2) UpsertShows(_ context.Context, _ []store.Show) error {
+	m.upsertShowsCalled = true
+	return m.err
+}
+func (m *mockVenueStore2) UpsertArtists(_ context.Context, _ []store.Artist) error {
+	m.upsertArtistsCalled = true
+	return m.err
+}
+func (m *mockVenueStore2) UpsertShowArtists(_ context.Context, _ []store.ShowArtist) error {
+	m.upsertShowArtistsCalled = true
+	return m.err
+}
+func (m *mockVenueStore2) UpsertShowClassifications(_ context.Context, _ []store.ShowClassification) error {
+	m.upsertClassificationsCalled = true
+	return m.err
+}
+func (m *mockVenueStore2) GetVenueFetchedAt(_ context.Context, _ string) (*time.Time, error) {
+	return m.fetchedAt, nil
+}
+func (m *mockVenueStore2) GetVenues(_ context.Context) ([]store.Venue, error) {
+	return m.venues, m.err
+}
+func (m *mockVenueStore2) GetShowsForVenues(_ context.Context, _ []string) (map[string][]store.ShowSummary, error) {
+	return m.showsByVenue, nil
+}
+func (m *mockVenueStore2) GetAllVenueArtists(_ context.Context, _ []string) (map[string][]store.VenueArtist, error) {
+	return m.artistsByVenue, nil
+}
+func (m *mockVenueStore2) GetAllVenueVibes(_ context.Context, _ []string) (map[string]map[string]float32, error) {
+	return m.vibesByVenue, nil
+}
+func (m *mockVenueStore2) UpsertVenueVibes(_ context.Context, _ string, _ map[string]float32) error {
+	m.upsertVibesCalled = true
+	return nil
+}
+
+func TestSyncVenues_TTLSkip(t *testing.T) {
+	recent := time.Now().Add(-1 * time.Hour)
+	vs := &mockVenueStore2{fetchedAt: &recent}
+
+	cache := newMockTagCache()
+	enricher := NewTagEnricher(&mockLastFM{}, cache)
+
+	svc, err := NewVenueService(&mockTicketmaster{}, vs, enricher)
+	if err != nil {
+		t.Fatalf("NewVenueService: %v", err)
+	}
+
+	result, err := svc.SyncVenues(context.Background())
+	if err != nil {
+		t.Fatalf("SyncVenues: %v", err)
+	}
+
+	if !result.Skipped {
+		t.Error("expected sync to be skipped when data is fresh")
+	}
+	if vs.upsertVenuesCalled {
+		t.Error("expected UpsertVenues NOT to be called")
+	}
+}
+
+func TestSyncVenueVibes_Success(t *testing.T) {
+	vs := &mockVenueStore2{
+		venues: []store.Venue{
+			{ID: "v1", Name: "Test Venue", ShowsTracked: 2},
+		},
+		artistsByVenue: map[string][]store.VenueArtist{
+			"v1": {
+				{ArtistName: "artist one", ShowDate: time.Now()},
+			},
+		},
+	}
+
+	cache := newMockTagCache()
+	cache.cached["artist one"] = []lastfm.Tag{{Name: "rock", Count: 100}}
+	enricher := NewTagEnricher(&mockLastFM{}, cache)
+
+	svc, err := NewVenueService(&mockTicketmaster{}, vs, enricher)
+	if err != nil {
+		t.Fatalf("NewVenueService: %v", err)
+	}
+
+	computed, err := svc.SyncVenueVibes(context.Background())
+	if err != nil {
+		t.Fatalf("SyncVenueVibes: %v", err)
+	}
+
+	if computed != 1 {
+		t.Errorf("expected 1 venue vibe computed, got %d", computed)
+	}
+	if !vs.upsertVibesCalled {
+		t.Error("expected UpsertVenueVibes to be called")
+	}
+}
+
+func TestGetVenues_Success(t *testing.T) {
+	vs := &mockVenueStore2{
+		venues: []store.Venue{
+			{ID: "v1", Name: "Venue A", ShowsTracked: 3},
+			{ID: "v2", Name: "Venue B", ShowsTracked: 0}, // no shows, filtered
+		},
+		showsByVenue: map[string][]store.ShowSummary{
+			"v1": {{Name: "Show 1", Date: time.Now()}},
+		},
+		vibesByVenue: map[string]map[string]float32{
+			"v1": {"rock": 0.9},
+		},
+	}
+
+	cache := newMockTagCache()
+	enricher := NewTagEnricher(&mockLastFM{}, cache)
+
+	svc, _ := NewVenueService(&mockTicketmaster{}, vs, enricher)
+
+	venues, err := svc.GetVenues(context.Background())
+	if err != nil {
+		t.Fatalf("GetVenues: %v", err)
+	}
+
+	if len(venues) != 1 {
+		t.Fatalf("expected 1 venue (with shows), got %d", len(venues))
+	}
+	if venues[0].Name != "Venue A" {
+		t.Errorf("expected 'Venue A', got %q", venues[0].Name)
+	}
+	if len(venues[0].Shows) != 1 {
+		t.Errorf("expected 1 show, got %d", len(venues[0].Shows))
+	}
+	if venues[0].Vibes["rock"] != 0.9 {
+		t.Errorf("expected rock=0.9, got %f", venues[0].Vibes["rock"])
+	}
+}
+
+func TestGetVenues_Empty(t *testing.T) {
+	vs := &mockVenueStore2{venues: []store.Venue{}}
+	cache := newMockTagCache()
+	enricher := NewTagEnricher(&mockLastFM{}, cache)
+
+	svc, _ := NewVenueService(&mockTicketmaster{}, vs, enricher)
+
+	venues, err := svc.GetVenues(context.Background())
+	if err != nil {
+		t.Fatalf("GetVenues: %v", err)
+	}
+
+	if len(venues) != 0 {
+		t.Errorf("expected 0 venues, got %d", len(venues))
+	}
+}
+
+func TestNewVenueService_NilDeps(t *testing.T) {
+	cache := newMockTagCache()
+	enricher := NewTagEnricher(&mockLastFM{}, cache)
+	tm := &mockTicketmaster{}
+	vs := &mockVenueStore2{}
+
+	if _, err := NewVenueService(nil, vs, enricher); err == nil {
+		t.Error("expected error for nil ticketmaster")
+	}
+	if _, err := NewVenueService(tm, nil, enricher); err == nil {
+		t.Error("expected error for nil venue store")
+	}
+	if _, err := NewVenueService(tm, vs, nil); err == nil {
+		t.Error("expected error for nil tag enricher")
+	}
+}
+
+func TestMapVenues_FiltersNonUS(t *testing.T) {
+	tmVenues := []ticketmaster.Venue{
+		{
+			ID:       "v1",
+			Name:     "Bowery Ballroom",
+			Location: ticketmaster.VenueLocation{Latitude: "40.7204", Longitude: "-73.9934"},
+			Country:  ticketmaster.VenueCountry{CountryCode: "US"},
+		},
+		{
+			ID:       "v2",
+			Name:     "Spanish Venue",
+			Location: ticketmaster.VenueLocation{Latitude: "40.7", Longitude: "-74.0"},
+			Country:  ticketmaster.VenueCountry{CountryCode: "ES"},
+		},
+	}
+
+	result := MapVenues(tmVenues)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 venue, got %d", len(result))
+	}
+	if result[0].Name != "Bowery Ballroom" {
+		t.Errorf("expected Bowery Ballroom, got %q", result[0].Name)
+	}
+}
+
+func TestMapVenues_FiltersNoCoordinates(t *testing.T) {
+	tmVenues := []ticketmaster.Venue{
+		{
+			ID:       "v1",
+			Name:     "No Coords",
+			Location: ticketmaster.VenueLocation{Latitude: "0", Longitude: "0"},
+			Country:  ticketmaster.VenueCountry{CountryCode: "US"},
+		},
+	}
+
+	result := MapVenues(tmVenues)
+	if len(result) != 0 {
+		t.Fatalf("expected 0 venues (no coords), got %d", len(result))
+	}
+}

--- a/backend/internal/service/venue_test.go
+++ b/backend/internal/service/venue_test.go
@@ -84,7 +84,7 @@ func TestSyncVenues_TTLSkip(t *testing.T) {
 	vs := &mockVenueStore2{fetchedAt: &recent}
 
 	cache := newMockTagCache()
-	enricher := NewTagEnricher(&mockLastFM{}, cache)
+	enricher, _ := NewTagEnricher(&mockLastFM{}, cache)
 
 	svc, err := NewVenueService(&mockTicketmaster{}, vs, enricher)
 	if err != nil {
@@ -118,7 +118,7 @@ func TestSyncVenueVibes_Success(t *testing.T) {
 
 	cache := newMockTagCache()
 	cache.cached["artist one"] = []lastfm.Tag{{Name: "rock", Count: 100}}
-	enricher := NewTagEnricher(&mockLastFM{}, cache)
+	enricher, _ := NewTagEnricher(&mockLastFM{}, cache)
 
 	svc, err := NewVenueService(&mockTicketmaster{}, vs, enricher)
 	if err != nil {
@@ -153,7 +153,7 @@ func TestGetVenues_Success(t *testing.T) {
 	}
 
 	cache := newMockTagCache()
-	enricher := NewTagEnricher(&mockLastFM{}, cache)
+	enricher, _ := NewTagEnricher(&mockLastFM{}, cache)
 
 	svc, _ := NewVenueService(&mockTicketmaster{}, vs, enricher)
 
@@ -179,7 +179,7 @@ func TestGetVenues_Success(t *testing.T) {
 func TestGetVenues_Empty(t *testing.T) {
 	vs := &mockVenueStore2{venues: []store.Venue{}}
 	cache := newMockTagCache()
-	enricher := NewTagEnricher(&mockLastFM{}, cache)
+	enricher, _ := NewTagEnricher(&mockLastFM{}, cache)
 
 	svc, _ := NewVenueService(&mockTicketmaster{}, vs, enricher)
 
@@ -195,7 +195,7 @@ func TestGetVenues_Empty(t *testing.T) {
 
 func TestNewVenueService_NilDeps(t *testing.T) {
 	cache := newMockTagCache()
-	enricher := NewTagEnricher(&mockLastFM{}, cache)
+	enricher, _ := NewTagEnricher(&mockLastFM{}, cache)
 	tm := &mockTicketmaster{}
 	vs := &mockVenueStore2{}
 

--- a/backend/internal/service/vibe.go
+++ b/backend/internal/service/vibe.go
@@ -152,8 +152,13 @@ func (s *VibeService) ensureValidToken(ctx context.Context, userID string) (stri
 			return "", err
 		}
 
+		refreshToken := tokens.RefreshToken
+		if refreshed.RefreshToken != "" {
+			refreshToken = refreshed.RefreshToken
+		}
+
 		newExpiry := int(time.Now().Unix()) + refreshed.ExpiresIn
-		if err := s.tokens.UpdateTokens(ctx, userID, refreshed.AccessToken, refreshed.RefreshToken, newExpiry); err != nil {
+		if err := s.tokens.UpdateTokens(ctx, userID, refreshed.AccessToken, refreshToken, newExpiry); err != nil {
 			return "", err
 		}
 

--- a/backend/internal/service/vibe.go
+++ b/backend/internal/service/vibe.go
@@ -1,0 +1,164 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/pseudo/vibe-seeker/backend/internal/configuration"
+	"github.com/pseudo/vibe-seeker/backend/internal/observability"
+	"github.com/pseudo/vibe-seeker/backend/internal/spotify"
+	"github.com/pseudo/vibe-seeker/backend/internal/store"
+	"github.com/pseudo/vibe-seeker/backend/internal/vibes"
+)
+
+// TokenStore reads and writes Spotify tokens.
+type TokenStore interface {
+	GetTokens(ctx context.Context, userID string) (*store.UserTokens, error)
+	UpdateTokens(ctx context.Context, userID, accessToken, refreshToken string, tokenExpiry int) error
+}
+
+// VibeStore reads and writes user vibe profiles.
+type VibeStore interface {
+	UpsertVibes(ctx context.Context, userID string, vibes map[string]float32) error
+	GetVibes(ctx context.Context, userID string) (map[string]float32, error)
+}
+
+// SpotifyVibeClient provides the Spotify methods needed for vibe syncing.
+type SpotifyVibeClient interface {
+	FetchTopArtists(ctx context.Context, accessToken, timeRange string, limit int) (*spotify.TopArtistsResponse, error)
+	RefreshToken(ctx context.Context, refreshToken string) (*spotify.TokenResponse, error)
+}
+
+// VibeSyncResult contains the outcome of a vibe sync operation.
+type VibeSyncResult struct {
+	VibeCount int
+}
+
+// VibeService orchestrates user vibe profile syncing: Spotify top artists →
+// tag enrichment → vibe computation → persistence.
+type VibeService struct {
+	spotify     SpotifyVibeClient
+	tokens      TokenStore
+	vibes       VibeStore
+	tagEnricher *TagEnricher
+}
+
+// NewVibeService creates a VibeService.
+func NewVibeService(sp SpotifyVibeClient, tokens TokenStore, vibeStore VibeStore, enricher *TagEnricher) (*VibeService, error) {
+	if sp == nil {
+		return nil, errors.New("vibe service: nil spotify client")
+	}
+	if tokens == nil {
+		return nil, errors.New("vibe service: nil token store")
+	}
+	if vibeStore == nil {
+		return nil, errors.New("vibe service: nil vibe store")
+	}
+	if enricher == nil {
+		return nil, errors.New("vibe service: nil tag enricher")
+	}
+	return &VibeService{
+		spotify:     sp,
+		tokens:      tokens,
+		vibes:       vibeStore,
+		tagEnricher: enricher,
+	}, nil
+}
+
+// SyncVibe fetches the user's top artists from Spotify, enriches them with
+// tags, computes weighted vibe scores, and persists the result.
+func (s *VibeService) SyncVibe(ctx context.Context, userID string) (*VibeSyncResult, error) {
+	accessToken, err := s.ensureValidToken(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("authenticating with spotify: %w", err)
+	}
+
+	mediumResp, err := s.spotify.FetchTopArtists(ctx, accessToken, "medium_term", 50)
+	if err != nil {
+		return nil, fmt.Errorf("fetching medium-term top artists: %w", err)
+	}
+
+	shortResp, err := s.spotify.FetchTopArtists(ctx, accessToken, "short_term", 50)
+	if err != nil {
+		return nil, fmt.Errorf("fetching short-term top artists: %w", err)
+	}
+
+	// Build weighted artists and collect unique names.
+	var weighted []vibes.WeightedArtist
+	seen := make(map[string]bool)
+
+	for i, a := range mediumResp.Items {
+		rankWeight := float32(1.0) - float32(i)*0.02
+		if rankWeight < 0 {
+			rankWeight = 0
+		}
+		weighted = append(weighted, vibes.WeightedArtist{
+			Name: a.Name, Weight: rankWeight * 1.0, // medium_term multiplier
+		})
+		seen[strings.ToLower(a.Name)] = true
+	}
+	for i, a := range shortResp.Items {
+		rankWeight := float32(1.0) - float32(i)*0.02
+		if rankWeight < 0 {
+			rankWeight = 0
+		}
+		weighted = append(weighted, vibes.WeightedArtist{
+			Name: a.Name, Weight: rankWeight * 0.5, // short_term multiplier
+		})
+		seen[strings.ToLower(a.Name)] = true
+	}
+
+	// Enrich artists with tags using a dedicated timeout.
+	tagCtx, tagCancel := context.WithTimeout(context.WithoutCancel(ctx), configuration.VibeSyncTimeout)
+	defer tagCancel()
+
+	uniqueNames := make([]string, 0, len(seen))
+	for name := range seen {
+		uniqueNames = append(uniqueNames, name)
+	}
+
+	enrichResult := s.tagEnricher.Enrich(tagCtx, uniqueNames, configuration.LastFMRateLimit)
+	weights := vibes.ComputeVibes(enrichResult.ArtistTags, weighted)
+
+	// Use a fresh context for the DB write — the data is already in memory,
+	// so we don't want the tag timeout to prevent saving results.
+	dbCtx := context.WithoutCancel(ctx)
+	if err := s.vibes.UpsertVibes(dbCtx, userID, weights); err != nil {
+		return nil, fmt.Errorf("persisting vibe weights: %w", err)
+	}
+
+	observability.Logger(ctx).Info("vibe sync complete", "user", userID, "tags", len(weights))
+	return &VibeSyncResult{VibeCount: len(weights)}, nil
+}
+
+// GetVibe returns the user's stored vibe weights.
+func (s *VibeService) GetVibe(ctx context.Context, userID string) (map[string]float32, error) {
+	return s.vibes.GetVibes(ctx, userID)
+}
+
+// ensureValidToken returns a valid access token, refreshing it if expired.
+func (s *VibeService) ensureValidToken(ctx context.Context, userID string) (string, error) {
+	tokens, err := s.tokens.GetTokens(ctx, userID)
+	if err != nil {
+		return "", err
+	}
+
+	if int64(tokens.TokenExpiry) <= time.Now().Unix()+configuration.TokenRefreshThreshold {
+		refreshed, err := s.spotify.RefreshToken(ctx, tokens.RefreshToken)
+		if err != nil {
+			return "", err
+		}
+
+		newExpiry := int(time.Now().Unix()) + refreshed.ExpiresIn
+		if err := s.tokens.UpdateTokens(ctx, userID, refreshed.AccessToken, refreshed.RefreshToken, newExpiry); err != nil {
+			return "", err
+		}
+
+		return refreshed.AccessToken, nil
+	}
+
+	return tokens.AccessToken, nil
+}

--- a/backend/internal/service/vibe_test.go
+++ b/backend/internal/service/vibe_test.go
@@ -1,0 +1,241 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/pseudo/vibe-seeker/backend/internal/lastfm"
+	"github.com/pseudo/vibe-seeker/backend/internal/spotify"
+	"github.com/pseudo/vibe-seeker/backend/internal/store"
+)
+
+type mockSpotifyVibe struct {
+	topArtists map[string]*spotify.TopArtistsResponse
+	refreshResp *spotify.TokenResponse
+	fetchErr    error
+	refreshErr  error
+}
+
+func (m *mockSpotifyVibe) FetchTopArtists(_ context.Context, _, timeRange string, _ int) (*spotify.TopArtistsResponse, error) {
+	if m.fetchErr != nil {
+		return nil, m.fetchErr
+	}
+	return m.topArtists[timeRange], nil
+}
+
+func (m *mockSpotifyVibe) RefreshToken(_ context.Context, _ string) (*spotify.TokenResponse, error) {
+	return m.refreshResp, m.refreshErr
+}
+
+type mockTokenStore struct {
+	tokens       *store.UserTokens
+	err          error
+	updateCalled bool
+}
+
+func (m *mockTokenStore) GetTokens(_ context.Context, _ string) (*store.UserTokens, error) {
+	return m.tokens, m.err
+}
+
+func (m *mockTokenStore) UpdateTokens(_ context.Context, _, _, _ string, _ int) error {
+	m.updateCalled = true
+	return m.err
+}
+
+type mockVibeStore struct {
+	upsertCalled bool
+	upsertVibes  map[string]float32
+	upsertErr    error
+	getVibes     map[string]float32
+	getErr       error
+}
+
+func (m *mockVibeStore) UpsertVibes(_ context.Context, _ string, vibes map[string]float32) error {
+	m.upsertCalled = true
+	m.upsertVibes = vibes
+	return m.upsertErr
+}
+
+func (m *mockVibeStore) GetVibes(_ context.Context, _ string) (map[string]float32, error) {
+	return m.getVibes, m.getErr
+}
+
+func newTestVibeService(t *testing.T) (*VibeService, *mockVibeStore) {
+	t.Helper()
+
+	sp := &mockSpotifyVibe{
+		topArtists: map[string]*spotify.TopArtistsResponse{
+			"medium_term": {Items: []spotify.Artist{
+				{ID: "a1", Name: "Artist One"},
+				{ID: "a2", Name: "Artist Two"},
+			}},
+			"short_term": {Items: []spotify.Artist{
+				{ID: "a3", Name: "Artist Three"},
+			}},
+		},
+	}
+
+	cache := newMockTagCache()
+	cache.cached["artist one"] = []lastfm.Tag{{Name: "rock", Count: 100}}
+	cache.cached["artist two"] = []lastfm.Tag{{Name: "indie", Count: 80}}
+	cache.cached["artist three"] = []lastfm.Tag{{Name: "jazz", Count: 70}}
+
+	enricher := NewTagEnricher(&mockLastFM{}, cache)
+	vibeStore := &mockVibeStore{}
+
+	svc, err := NewVibeService(sp,
+		&mockTokenStore{tokens: &store.UserTokens{
+			AccessToken: "valid-token", RefreshToken: "refresh",
+			TokenExpiry: int(time.Now().Unix()) + 3600,
+		}},
+		vibeStore,
+		enricher,
+	)
+	if err != nil {
+		t.Fatalf("NewVibeService: %v", err)
+	}
+	return svc, vibeStore
+}
+
+func TestSyncVibe_Success(t *testing.T) {
+	svc, vibeStore := newTestVibeService(t)
+
+	result, err := svc.SyncVibe(context.Background(), "user1")
+	if err != nil {
+		t.Fatalf("SyncVibe: %v", err)
+	}
+
+	if result.VibeCount == 0 {
+		t.Error("expected non-zero vibe count")
+	}
+	if !vibeStore.upsertCalled {
+		t.Error("expected UpsertVibes to be called")
+	}
+	if _, ok := vibeStore.upsertVibes["rock"]; !ok {
+		t.Error("expected 'rock' in computed vibes")
+	}
+}
+
+func TestSyncVibe_TokenRefresh(t *testing.T) {
+	sp := &mockSpotifyVibe{
+		topArtists: map[string]*spotify.TopArtistsResponse{
+			"medium_term": {Items: []spotify.Artist{{ID: "a1", Name: "A"}}},
+			"short_term":  {Items: []spotify.Artist{}},
+		},
+		refreshResp: &spotify.TokenResponse{
+			AccessToken: "new-token", RefreshToken: "new-refresh", ExpiresIn: 3600,
+		},
+	}
+
+	tokenStore := &mockTokenStore{tokens: &store.UserTokens{
+		AccessToken: "expired", RefreshToken: "old-refresh",
+		TokenExpiry: int(time.Now().Unix()) - 100,
+	}}
+
+	cache := newMockTagCache()
+	cache.cached["a"] = []lastfm.Tag{{Name: "rock", Count: 100}}
+
+	svc, _ := NewVibeService(sp, tokenStore, &mockVibeStore{}, NewTagEnricher(&mockLastFM{}, cache))
+
+	_, err := svc.SyncVibe(context.Background(), "user1")
+	if err != nil {
+		t.Fatalf("SyncVibe: %v", err)
+	}
+
+	if !tokenStore.updateCalled {
+		t.Error("expected token refresh to be triggered")
+	}
+}
+
+func TestSyncVibe_SpotifyError(t *testing.T) {
+	sp := &mockSpotifyVibe{fetchErr: errors.New("spotify down")}
+	cache := newMockTagCache()
+
+	svc, _ := NewVibeService(sp,
+		&mockTokenStore{tokens: &store.UserTokens{
+			AccessToken: "valid", RefreshToken: "refresh",
+			TokenExpiry: int(time.Now().Unix()) + 3600,
+		}},
+		&mockVibeStore{},
+		NewTagEnricher(&mockLastFM{}, cache),
+	)
+
+	_, err := svc.SyncVibe(context.Background(), "user1")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestGetVibe_Success(t *testing.T) {
+	svc, _ := newTestVibeService(t)
+	// Override the vibe store's get result directly through the service
+	// by creating a new service with specific store state.
+	sp := &mockSpotifyVibe{}
+	vibeStore := &mockVibeStore{getVibes: map[string]float32{"rock": 1.0, "indie": 0.7}}
+	cache := newMockTagCache()
+	svc2, _ := NewVibeService(sp,
+		&mockTokenStore{tokens: &store.UserTokens{
+			AccessToken: "t", RefreshToken: "r",
+			TokenExpiry: int(time.Now().Unix()) + 3600,
+		}},
+		vibeStore,
+		NewTagEnricher(&mockLastFM{}, cache),
+	)
+	_ = svc // silence unused
+
+	vibes, err := svc2.GetVibe(context.Background(), "user1")
+	if err != nil {
+		t.Fatalf("GetVibe: %v", err)
+	}
+	if vibes["rock"] != 1.0 {
+		t.Errorf("rock = %f, want 1.0", vibes["rock"])
+	}
+}
+
+func TestGetVibe_Error(t *testing.T) {
+	sp := &mockSpotifyVibe{}
+	cache := newMockTagCache()
+	svc, _ := NewVibeService(sp,
+		&mockTokenStore{tokens: &store.UserTokens{
+			AccessToken: "t", RefreshToken: "r",
+			TokenExpiry: int(time.Now().Unix()) + 3600,
+		}},
+		&mockVibeStore{getErr: errors.New("db error")},
+		NewTagEnricher(&mockLastFM{}, cache),
+	)
+
+	_, err := svc.GetVibe(context.Background(), "user1")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestNewVibeService_NilDeps(t *testing.T) {
+	cache := newMockTagCache()
+	enricher := NewTagEnricher(&mockLastFM{}, cache)
+	tokens := &mockTokenStore{tokens: &store.UserTokens{}}
+	vibes := &mockVibeStore{}
+	sp := &mockSpotifyVibe{}
+
+	tests := []struct {
+		name string
+		sp   SpotifyVibeClient
+		tok  TokenStore
+		vib  VibeStore
+		enr  *TagEnricher
+	}{
+		{"nil spotify", nil, tokens, vibes, enricher},
+		{"nil tokens", sp, nil, vibes, enricher},
+		{"nil vibes", sp, tokens, nil, enricher},
+		{"nil enricher", sp, tokens, vibes, nil},
+	}
+
+	for _, tt := range tests {
+		_, err := NewVibeService(tt.sp, tt.tok, tt.vib, tt.enr)
+		if err == nil {
+			t.Errorf("%s: expected error", tt.name)
+		}
+	}
+}

--- a/backend/internal/service/vibe_test.go
+++ b/backend/internal/service/vibe_test.go
@@ -82,7 +82,7 @@ func newTestVibeService(t *testing.T) (*VibeService, *mockVibeStore) {
 	cache.cached["artist two"] = []lastfm.Tag{{Name: "indie", Count: 80}}
 	cache.cached["artist three"] = []lastfm.Tag{{Name: "jazz", Count: 70}}
 
-	enricher := NewTagEnricher(&mockLastFM{}, cache)
+	enricher, _ := NewTagEnricher(&mockLastFM{}, cache)
 	vibeStore := &mockVibeStore{}
 
 	svc, err := NewVibeService(sp,
@@ -137,7 +137,8 @@ func TestSyncVibe_TokenRefresh(t *testing.T) {
 	cache := newMockTagCache()
 	cache.cached["a"] = []lastfm.Tag{{Name: "rock", Count: 100}}
 
-	svc, _ := NewVibeService(sp, tokenStore, &mockVibeStore{}, NewTagEnricher(&mockLastFM{}, cache))
+	enricher, _ := NewTagEnricher(&mockLastFM{}, cache)
+	svc, _ := NewVibeService(sp, tokenStore, &mockVibeStore{}, enricher)
 
 	_, err := svc.SyncVibe(context.Background(), "user1")
 	if err != nil {
@@ -152,6 +153,7 @@ func TestSyncVibe_TokenRefresh(t *testing.T) {
 func TestSyncVibe_SpotifyError(t *testing.T) {
 	sp := &mockSpotifyVibe{fetchErr: errors.New("spotify down")}
 	cache := newMockTagCache()
+	enricher, _ := NewTagEnricher(&mockLastFM{}, cache)
 
 	svc, _ := NewVibeService(sp,
 		&mockTokenStore{tokens: &store.UserTokens{
@@ -159,7 +161,7 @@ func TestSyncVibe_SpotifyError(t *testing.T) {
 			TokenExpiry: int(time.Now().Unix()) + 3600,
 		}},
 		&mockVibeStore{},
-		NewTagEnricher(&mockLastFM{}, cache),
+		enricher,
 	)
 
 	_, err := svc.SyncVibe(context.Background(), "user1")
@@ -175,13 +177,14 @@ func TestGetVibe_Success(t *testing.T) {
 	sp := &mockSpotifyVibe{}
 	vibeStore := &mockVibeStore{getVibes: map[string]float32{"rock": 1.0, "indie": 0.7}}
 	cache := newMockTagCache()
+	enricher, _ := NewTagEnricher(&mockLastFM{}, cache)
 	svc2, _ := NewVibeService(sp,
 		&mockTokenStore{tokens: &store.UserTokens{
 			AccessToken: "t", RefreshToken: "r",
 			TokenExpiry: int(time.Now().Unix()) + 3600,
 		}},
 		vibeStore,
-		NewTagEnricher(&mockLastFM{}, cache),
+		enricher,
 	)
 	_ = svc // silence unused
 
@@ -197,13 +200,14 @@ func TestGetVibe_Success(t *testing.T) {
 func TestGetVibe_Error(t *testing.T) {
 	sp := &mockSpotifyVibe{}
 	cache := newMockTagCache()
+	enricher, _ := NewTagEnricher(&mockLastFM{}, cache)
 	svc, _ := NewVibeService(sp,
 		&mockTokenStore{tokens: &store.UserTokens{
 			AccessToken: "t", RefreshToken: "r",
 			TokenExpiry: int(time.Now().Unix()) + 3600,
 		}},
 		&mockVibeStore{getErr: errors.New("db error")},
-		NewTagEnricher(&mockLastFM{}, cache),
+		enricher,
 	)
 
 	_, err := svc.GetVibe(context.Background(), "user1")
@@ -214,7 +218,7 @@ func TestGetVibe_Error(t *testing.T) {
 
 func TestNewVibeService_NilDeps(t *testing.T) {
 	cache := newMockTagCache()
-	enricher := NewTagEnricher(&mockLastFM{}, cache)
+	enricher, _ := NewTagEnricher(&mockLastFM{}, cache)
 	tokens := &mockTokenStore{tokens: &store.UserTokens{}}
 	vibes := &mockVibeStore{}
 	sp := &mockSpotifyVibe{}

--- a/backend/internal/webserver/server.go
+++ b/backend/internal/webserver/server.go
@@ -46,7 +46,10 @@ func New(cfg configuration.Config, pool *pgxpool.Pool) (*http.Server, error) {
 	tmClient := ticketmaster.NewClient(cfg.TicketmasterAPIKey)
 
 	// --- Services ---
-	tagEnricher := service.NewTagEnricher(lastfmClient, artistTagStore)
+	tagEnricher, err := service.NewTagEnricher(lastfmClient, artistTagStore)
+	if err != nil {
+		return nil, fmt.Errorf("creating tag enricher: %w", err)
+	}
 
 	authSvc, err := service.NewAuthService(spotifyClient, userStore, cfg.JWTSecret, cfg.TurnstileSecretKey)
 	if err != nil {

--- a/backend/internal/webserver/server.go
+++ b/backend/internal/webserver/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pseudo/vibe-seeker/backend/internal/handlers"
 	"github.com/pseudo/vibe-seeker/backend/internal/lastfm"
 	"github.com/pseudo/vibe-seeker/backend/internal/middleware"
+	"github.com/pseudo/vibe-seeker/backend/internal/service"
 	"github.com/pseudo/vibe-seeker/backend/internal/spotify"
 	"github.com/pseudo/vibe-seeker/backend/internal/store"
 	"github.com/pseudo/vibe-seeker/backend/internal/ticketmaster"
@@ -25,13 +26,50 @@ func New(cfg configuration.Config, pool *pgxpool.Pool) (*http.Server, error) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/health", handlers.HealthCheck)
 
+	// --- Stores ---
 	userStore, err := store.NewUserStore(pool)
 	if err != nil {
 		return nil, fmt.Errorf("creating user store: %w", err)
 	}
+	artistTagStore, err := store.NewArtistTagStore(pool)
+	if err != nil {
+		return nil, fmt.Errorf("creating artist tag store: %w", err)
+	}
+	venueStore, err := store.NewVenueStore(pool)
+	if err != nil {
+		return nil, fmt.Errorf("creating venue store: %w", err)
+	}
 
+	// --- API Clients ---
 	spotifyClient := spotify.NewClient(cfg.SpotifyClientID, cfg.SpotifyClientSecret, cfg.SpotifyRedirectURI)
-	authHandler, err := handlers.NewAuthHandler(spotifyClient, userStore, cfg.JWTSecret, cfg.FrontendURL, cfg.TurnstileSecretKey, cfg.SecureCookie)
+	lastfmClient := lastfm.NewClient(cfg.LastFMAPIKey)
+	tmClient := ticketmaster.NewClient(cfg.TicketmasterAPIKey)
+
+	// --- Services ---
+	tagEnricher := service.NewTagEnricher(lastfmClient, artistTagStore)
+
+	authSvc, err := service.NewAuthService(spotifyClient, userStore, cfg.JWTSecret, cfg.TurnstileSecretKey)
+	if err != nil {
+		return nil, fmt.Errorf("creating auth service: %w", err)
+	}
+
+	vibeSvc, err := service.NewVibeService(spotifyClient, userStore, userStore, tagEnricher)
+	if err != nil {
+		return nil, fmt.Errorf("creating vibe service: %w", err)
+	}
+
+	venueSvc, err := service.NewVenueService(tmClient, venueStore, tagEnricher)
+	if err != nil {
+		return nil, fmt.Errorf("creating venue service: %w", err)
+	}
+
+	exploreSvc, err := service.NewExploreService(artistTagStore)
+	if err != nil {
+		return nil, fmt.Errorf("creating explore service: %w", err)
+	}
+
+	// --- Handlers ---
+	authHandler, err := handlers.NewAuthHandler(spotifyClient, authSvc, cfg.FrontendURL, cfg.SecureCookie)
 	if err != nil {
 		return nil, fmt.Errorf("creating auth handler: %w", err)
 	}
@@ -45,24 +83,14 @@ func New(cfg configuration.Config, pool *pgxpool.Pool) (*http.Server, error) {
 	requireAuth := middleware.RequireAuth(cfg.JWTSecret)
 	mux.Handle("GET /api/auth/me", requireAuth(http.HandlerFunc(authHandler.Me)))
 
-	lastfmClient := lastfm.NewClient(cfg.LastFMAPIKey)
-	artistTagStore, err := store.NewArtistTagStore(pool)
-	if err != nil {
-		return nil, fmt.Errorf("creating artist tag store: %w", err)
-	}
-	vibeHandler, err := handlers.NewVibeHandler(spotifyClient, lastfmClient, userStore, userStore, artistTagStore)
+	vibeHandler, err := handlers.NewVibeHandler(vibeSvc)
 	if err != nil {
 		return nil, fmt.Errorf("creating vibe handler: %w", err)
 	}
 	mux.Handle("POST /api/vibe/sync", requireAuth(http.HandlerFunc(vibeHandler.SyncVibe)))
 	mux.Handle("GET /api/vibe", requireAuth(http.HandlerFunc(vibeHandler.GetVibe)))
 
-	tmClient := ticketmaster.NewClient(cfg.TicketmasterAPIKey)
-	venueStore, err := store.NewVenueStore(pool)
-	if err != nil {
-		return nil, fmt.Errorf("creating venue store: %w", err)
-	}
-	venueHandler, err := handlers.NewVenueHandler(tmClient, lastfmClient, venueStore, artistTagStore)
+	venueHandler, err := handlers.NewVenueHandler(venueSvc)
 	if err != nil {
 		return nil, fmt.Errorf("creating venue handler: %w", err)
 	}
@@ -70,7 +98,7 @@ func New(cfg configuration.Config, pool *pgxpool.Pool) (*http.Server, error) {
 	mux.Handle("POST /api/venues/vibes", requireAuth(http.HandlerFunc(venueHandler.SyncVenueVibes)))
 	mux.Handle("GET /api/venues", requireAuth(http.HandlerFunc(venueHandler.GetVenues)))
 
-	exploreHandler, err := handlers.NewExploreHandler(artistTagStore)
+	exploreHandler, err := handlers.NewExploreHandler(exploreSvc)
 	if err != nil {
 		return nil, fmt.Errorf("creating explore handler: %w", err)
 	}

--- a/frontend/src/hooks/useSyncAction.test.ts
+++ b/frontend/src/hooks/useSyncAction.test.ts
@@ -15,7 +15,7 @@ function mockFetch(response: Response) {
 describe("useSyncAction", () => {
   it("executes POST and returns result", async () => {
     mockFetch(
-      new Response(JSON.stringify({ synced: true, genre_count: 5 }), {
+      new Response(JSON.stringify({ synced: true, vibe_count: 5 }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       }),
@@ -23,7 +23,7 @@ describe("useSyncAction", () => {
     const refetch = vi.fn();
 
     const { result } = renderHook(() =>
-      useSyncAction<{ genre_count: number }>("/api/vibe/sync", {
+      useSyncAction<{ vibe_count: number }>("/api/vibe/sync", {
         errorMessage: "Sync failed.",
         refetch,
       }),
@@ -35,7 +35,7 @@ describe("useSyncAction", () => {
     await waitFor(() => {
       expect(result.current.syncing).toBe(false);
     });
-    expect(result.current.result?.genre_count).toBe(5);
+    expect(result.current.result?.vibe_count).toBe(5);
     expect(result.current.error).toBeNull();
     expect(refetch).toHaveBeenCalled();
   });

--- a/frontend/src/hooks/useVibes.test.ts
+++ b/frontend/src/hooks/useVibes.test.ts
@@ -15,7 +15,7 @@ function mockFetch(vibeResponse: Response) {
 describe("useVibes", () => {
   it("does not fetch when disabled", () => {
     const spy = mockFetch(
-      new Response(JSON.stringify({ genres: { rock: 1 }, genre_count: 1 }), {
+      new Response(JSON.stringify({ vibes: { rock: 1 }, vibe_count: 1 }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       }),
@@ -24,10 +24,10 @@ describe("useVibes", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it("fetches genres when enabled", async () => {
+  it("fetches vibes when enabled", async () => {
     mockFetch(
       new Response(
-        JSON.stringify({ genres: { rock: 1.0, indie: 0.5 }, genre_count: 2 }),
+        JSON.stringify({ vibes: { rock: 1.0, indie: 0.5 }, vibe_count: 2 }),
         { status: 200, headers: { "Content-Type": "application/json" } },
       ),
     );
@@ -36,7 +36,7 @@ describe("useVibes", () => {
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
     });
-    expect(result.current.genres).toEqual({ rock: 1.0, indie: 0.5 });
+    expect(result.current.vibes).toEqual({ rock: 1.0, indie: 0.5 });
     expect(result.current.error).toBeNull();
   });
 
@@ -47,7 +47,7 @@ describe("useVibes", () => {
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
     });
-    expect(result.current.genres).toBeNull();
+    expect(result.current.vibes).toBeNull();
     expect(result.current.error).toBeTruthy();
   });
 });

--- a/frontend/src/hooks/useVibes.ts
+++ b/frontend/src/hooks/useVibes.ts
@@ -2,14 +2,14 @@ import { useState, useEffect, useCallback } from "react";
 import { fetchVibe } from "../utils/api";
 
 interface UseVibesResult {
-  genres: Record<string, number> | null;
+  vibes: Record<string, number> | null;
   loading: boolean;
   error: string | null;
   refetch: () => void;
 }
 
 export function useVibes(enabled: boolean): UseVibesResult {
-  const [genres, setGenres] = useState<Record<string, number> | null>(null);
+  const [vibes, setVibes] = useState<Record<string, number> | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
   const [fetchKey, setFetchKey] = useState(0);
@@ -20,14 +20,14 @@ export function useVibes(enabled: boolean): UseVibesResult {
     fetchVibe()
       .then((data) => {
         if (!cancelled) {
-          setGenres(data.genres);
+          setVibes(data.vibes);
           setError(null);
           setPending(false);
         }
       })
       .catch(() => {
         if (!cancelled) {
-          setGenres(null);
+          setVibes(null);
           setError("Failed to load vibes.");
           setPending(false);
         }
@@ -43,7 +43,7 @@ export function useVibes(enabled: boolean): UseVibesResult {
     setFetchKey((k) => k + 1);
   }, []);
 
-  const loading = pending || (enabled && genres === null && error === null);
+  const loading = pending || (enabled && vibes === null && error === null);
 
-  return { genres, loading, error, refetch };
+  return { vibes, loading, error, refetch };
 }

--- a/frontend/src/pages/Home.test.tsx
+++ b/frontend/src/pages/Home.test.tsx
@@ -38,7 +38,7 @@ function mockFetch(overrides: Record<string, Response | (() => Response)> = {}) 
         { status: 200, headers: { "Content-Type": "application/json" } },
       ),
     "/api/vibe": () =>
-      new Response(JSON.stringify({ genres: {}, genre_count: 0 }), {
+      new Response(JSON.stringify({ vibes: {}, vibe_count: 0 }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       }),
@@ -144,8 +144,8 @@ describe("Home", () => {
     mockFetch({
       "/api/vibe": new Response(
         JSON.stringify({
-          genres: { rock: 1.0, indie: 0.7, "dream pop": 0.3 },
-          genre_count: 3,
+          vibes: { rock: 1.0, indie: 0.7, "dream pop": 0.3 },
+          vibe_count: 3,
         }),
         { status: 200, headers: { "Content-Type": "application/json" } },
       ),
@@ -167,14 +167,14 @@ describe("Home", () => {
     mockFetch({
       "/api/vibe": () => {
         vibeCalls++;
-        const genres = vibeCalls > 1 ? { rock: 1.0, indie: 0.5 } : {};
+        const vibeData = vibeCalls > 1 ? { rock: 1.0, indie: 0.5 } : {};
         return new Response(
-          JSON.stringify({ genres, genre_count: Object.keys(genres).length }),
+          JSON.stringify({ vibes: vibeData, vibe_count: Object.keys(vibeData).length }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         );
       },
       "/api/vibe/sync": new Response(
-        JSON.stringify({ synced: true, genre_count: 2 }),
+        JSON.stringify({ synced: true, vibe_count: 2 }),
         { status: 200, headers: { "Content-Type": "application/json" } },
       ),
     });

--- a/frontend/src/pages/Home.test.tsx
+++ b/frontend/src/pages/Home.test.tsx
@@ -162,7 +162,7 @@ describe("Home", () => {
     expect(screen.getByText("dream pop")).toBeInTheDocument();
   });
 
-  it("calls sync endpoint and refreshes genres on click", async () => {
+  it("calls sync endpoint and refreshes vibes on click", async () => {
     let vibeCalls = 0;
     mockFetch({
       "/api/vibe": () => {

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -24,16 +24,16 @@ export default function Home() {
       ? selectedVenue
       : null;
 
-  const graph = useVibeGraph(vibes.genres);
+  const graph = useVibeGraph(vibes.vibes);
 
   const { venueScores, visibleVenues } = useVenueMatching(
-    vibes.genres,
+    vibes.vibes,
     graph.selectedTags,
     venues.venues,
     minMatch,
   );
 
-  const vibeSync = useSyncAction<{ genre_count: number }>(
+  const vibeSync = useSyncAction<{ vibe_count: number }>(
     "/api/vibe/sync",
     { errorMessage: "Failed to sync vibe from Spotify.", refetch: vibes.refetch },
   );

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -24,8 +24,8 @@ export async function postLogout(): Promise<void> {
 }
 
 export async function fetchVibe(): Promise<{
-  genres: Record<string, number>;
-  genre_count: number;
+  vibes: Record<string, number>;
+  vibe_count: number;
 }> {
   const res = await fetch("/api/vibe", { credentials: "include" });
   if (!res.ok) throw new Error("failed to load vibe");


### PR DESCRIPTION
<!-- auto-changelog -->

## Changelog

### Bug Fixes

- [`f12d189`](https://github.com/swerdick/vibe-seeker/commit/f12d189) **backend**: preserve refresh token when Spotify omits it
- [`1e67a6c`](https://github.com/swerdick/vibe-seeker/commit/1e67a6c) **backend**: check HTTP status in Turnstile verification
- [`cb72e60`](https://github.com/swerdick/vibe-seeker/commit/cb72e60) **backend**: validate nil deps in NewTagEnricher

### Refactoring

- [`68e3ef1`](https://github.com/swerdick/vibe-seeker/commit/68e3ef1) **backend**: extract service layer from handlers
- [`2b89423`](https://github.com/swerdick/vibe-seeker/commit/2b89423) **frontend**: rename genres to vibes in API types and hooks

### Tests

- [`523168b`](https://github.com/swerdick/vibe-seeker/commit/523168b) fix leftover genres references in test descriptions
