### PR TITLE
feat(frontend): UI enhancements — guided tour, view toggle, login disclaimer

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/tf-plan-apply.yml
+++ b/.github/workflows/tf-plan-apply.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Comment PR
         if: always() && steps.plan.outcome != 'skipped'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const output = `#### Terraform Plan

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -213,8 +213,16 @@ a SHA256 hash in the `x-amz-content-sha256` header. The gotcha: this header must
 added by CloudFront. CloudFront includes whatever the viewer sends in its SigV4 computation.
 
 This means your frontend JavaScript needs to compute `SHA256(request_body)` for every POST request and include it as a
-header. For empty-body POSTs, it's a constant (`e3b0c44...`). For POSTs with bodies, you compute it dynamically via
-`crypto.subtle.digest("SHA-256", body)`. We centralized this into a shared `post()` helper in `api.ts`.
+header. For empty-body POSTs, it's a constant (`e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`).
+For POSTs with bodies, you compute it dynamically:
+
+```js
+const encoded = new TextEncoder().encode(body);
+const digest = await crypto.subtle.digest("SHA-256", encoded);
+const hash = Array.from(new Uint8Array(digest)).map(b => b.toString(16).padStart(2, "0")).join("");
+```
+
+We centralized this into a shared `post()` helper in `frontend/src/utils/api.ts`.
 
 Without this header, GET requests work fine (no body to hash) but every POST returns 403. The error message is the same
 generic "Forbidden" with no mention of the missing hash.

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -178,6 +178,59 @@ AWS console but are distinct APIs with distinct IAM actions. Worth budgeting an 
 missing when bootstrapping a new account: Terraform will tell you exactly which action is denied, but it'll only tell
 you one at a time per apply.
 
+## CloudFront OAC for Lambda URLs Has Underdocumented Requirements
+
+CloudFront Origin Access Control (OAC) lets you restrict a Lambda Function URL so only CloudFront can invoke it — no
+one can bypass CloudFront by hitting the Lambda URL directly. The concept is sound and the security benefit is real, but
+the setup has several gotchas that cost us hours of debugging.
+
+**You need TWO Lambda permissions, not one.** The AWS docs bury this in a code example: CloudFront OAC requires both
+`lambda:InvokeFunctionUrl` AND `lambda:InvokeFunction` permissions on the Lambda function. Every Terraform example and
+blog post I found only showed the first one. With only `InvokeFunctionUrl`, CloudFront's signed requests are rejected
+with a 403 `AccessDeniedException`. The error message doesn't hint at the missing permission — it just says "Forbidden."
+
+```hcl
+# Both are required. Missing the second one causes silent 403s.
+resource "aws_lambda_permission" "cloudfront_invoke_url" {
+  action                 = "lambda:InvokeFunctionUrl"
+  function_name          = aws_lambda_function.api.function_name
+  principal              = "cloudfront.amazonaws.com"
+  source_arn             = aws_cloudfront_distribution.this.arn
+  function_url_auth_type = "AWS_IAM"
+}
+
+resource "aws_lambda_permission" "cloudfront_invoke_function" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.api.function_name
+  principal     = "cloudfront.amazonaws.com"
+  source_arn    = aws_cloudfront_distribution.this.arn
+}
+```
+
+**POST and PUT requests require `x-amz-content-sha256` from the browser.** CloudFront OAC signs requests with SigV4,
+and Lambda validates the signature. For POST/PUT requests, Lambda requires the body to be included in the signature via
+a SHA256 hash in the `x-amz-content-sha256` header. The gotcha: this header must be sent by the *client* (browser), not
+added by CloudFront. CloudFront includes whatever the viewer sends in its SigV4 computation.
+
+This means your frontend JavaScript needs to compute `SHA256(request_body)` for every POST request and include it as a
+header. For empty-body POSTs, it's a constant (`e3b0c44...`). For POSTs with bodies, you compute it dynamically via
+`crypto.subtle.digest("SHA-256", body)`. We centralized this into a shared `post()` helper in `api.ts`.
+
+Without this header, GET requests work fine (no body to hash) but every POST returns 403. The error message is the same
+generic "Forbidden" with no mention of the missing hash.
+
+**The Lambda URL origin needs `custom_origin_config`.** Unlike S3 origins (which CloudFront auto-detects), Lambda
+Function URL origins are custom origins and require explicit `custom_origin_config` with `origin_protocol_policy =
+"https-only"`. Removing it (as I tried while debugging the 403) causes CloudFront to treat the Lambda URL domain as an
+S3 bucket, failing with "The parameter Origin DomainName does not refer to a valid S3 bucket." The OAC attaches
+alongside `custom_origin_config` — they're not mutually exclusive.
+
+**Debugging is hard.** Direct SigV4 curl to the Lambda URL works (`curl --aws-sigv4`), but CloudFront → Lambda returns
+403 with no actionable details. Standard CloudFront logs don't include auth headers. The only diagnostic that helped was
+checking the Lambda resource policy (`aws lambda get-policy`) and comparing it to the AWS docs' example — that's how we
+found the missing `InvokeFunction` permission. For the content hash issue, we found it in a single sentence in the docs
+that's easy to miss.
+
 ## The Algorithm Is Simple — The Data Pipeline Is Hard
 
 The actual matching math is ~30 lines of code (cosine similarity on two maps). The data pipeline to get clean, normalized, 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "maplibre-gl": "^5.23.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-joyride": "^3.0.2",
         "react-map-gl": "^8.1.1",
         "react-router-dom": "^7.14.0",
         "web-vitals": "^5.2.0"
@@ -694,6 +695,87 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fastify/deepmerge": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.2.1.tgz",
+      "integrity": "sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@gilbarbara/deep-equal": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.4.1.tgz",
+      "integrity": "sha512-QF2BGeQjsa59T59XvFdR3is5jrl28Eg0J6giXAC5919bcqvR8XP4B+07tpbs6Y6/IQd4FBncaL2WVXIBgSxt4w==",
+      "license": "MIT"
+    },
+    "node_modules/@gilbarbara/hooks": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/hooks/-/hooks-0.11.0.tgz",
+      "integrity": "sha512-CIVazdxqFRplUfm9wZL3/0X1TURJekhPMWGFdWzEmyJrGPiotX2yxA1KiB8N7VnhawIaMtb2Apnda4Y6DRwi2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.4.1"
+      },
+      "peerDependencies": {
+        "react": "16.8 - 19"
+      }
+    },
+    "node_modules/@gilbarbara/types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/types/-/types-0.2.2.tgz",
+      "integrity": "sha512-QuQDBRRcm1Q8AbSac2W1YElurOhprj3Iko/o+P1fJxUWS4rOGKMVli98OXS7uo4z+cKAif6a+L9bcZFSyauQpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.1.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1678,7 +1760,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2452,7 +2533,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-dispatch": {
@@ -3101,6 +3181,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-2.0.0.tgz",
+      "integrity": "sha512-70f2BMIQlbSUXVKaZUd9a9fJH3IH1PDckV0m4BIIO4LjnNYvOh4Ng7vXIXEwpA0KDZknRq+7fHwGTu0jIdx28g==",
+      "license": "MIT"
     },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
@@ -3980,6 +4066,16 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-innertext": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/react-innertext/-/react-innertext-1.1.5.tgz",
+      "integrity": "sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": ">=0.0.0 <=99",
+        "react": ">=0.0.0 <=99"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -3987,6 +4083,28 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-joyride": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-joyride/-/react-joyride-3.0.2.tgz",
+      "integrity": "sha512-Tm+zXo/O8rFOUkN1yH+t38HqLvOCB8p5JTqgQD3IlLyZGCXzJEnCXtyB/BQIUC7X07kEaw0BqtKjWFzF4fyDVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/deepmerge": "^3.2.1",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@gilbarbara/deep-equal": "^0.4.1",
+        "@gilbarbara/hooks": "^0.11.0",
+        "@gilbarbara/types": "^0.2.2",
+        "is-lite": "^2.0.0",
+        "react-innertext": "^1.1.5",
+        "scroll": "^3.0.1",
+        "scrollparent": "^2.1.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "16.8 - 19",
+        "react-dom": "16.8 - 19"
+      }
     },
     "node_modules/react-map-gl": {
       "version": "8.1.1",
@@ -4161,6 +4279,18 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/scroll": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz",
+      "integrity": "sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg==",
+      "license": "MIT"
+    },
+    "node_modules/scrollparent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz",
+      "integrity": "sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA==",
+      "license": "ISC"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -4478,6 +4608,18 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
@@ -4601,6 +4743,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "maplibre-gl": "^5.23.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-joyride": "^3.0.2",
     "react-map-gl": "^8.1.1",
     "react-router-dom": "^7.14.0",
     "web-vitals": "^5.2.0"

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -41,6 +41,28 @@
   gap: 0.5rem;
 }
 
+.tour-help-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background-color: transparent;
+  border: 1px solid #555;
+  border-radius: 50%;
+  color: #888;
+  font-size: 0.85rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.tour-help-btn:hover {
+  color: #fff;
+  border-color: #1db954;
+}
+
 .venue-count {
   font-size: 0.85rem;
   color: #999;
@@ -110,6 +132,73 @@
   color: #666;
   font-size: 0.9rem;
   text-align: center;
+}
+
+/* Vibe panel — wraps graph + list overlay */
+.vibe-panel {
+  flex: 1;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.vibe-view-toggle {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 10;
+  display: flex;
+  gap: 0.25rem;
+}
+
+.vibe-toggle-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background-color: #333;
+  border: 1px solid #555;
+  border-radius: 4px;
+  color: #888;
+  cursor: pointer;
+  transition: color 0.2s, background-color 0.2s;
+}
+
+.vibe-toggle-btn:hover {
+  background-color: #444;
+  color: #ccc;
+}
+
+.vibe-toggle-btn.active {
+  background-color: #1db954;
+  border-color: #1db954;
+  color: #fff;
+}
+
+.vibe-list-overlay {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: #1a1a1a;
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  z-index: 5;
+  overflow-y: auto;
+}
+
+.vibe-list-overlay.open {
+  transform: translateX(0);
+}
+
+.vibe-list-overlay .sidebar {
+  width: 100%;
+  border-left: none;
+  box-sizing: border-box;
 }
 
 /* Vibe Graph */

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -7,7 +7,7 @@
   height: 100vh;
   text-align: center;
   padding: 2rem;
-  overflow: hidden;
+  overflow-y: auto;
   box-sizing: border-box;
 }
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -279,6 +279,14 @@
   background-color: #777;
 }
 
+.login-disclaimer {
+  font-size: 0.75rem;
+  color: #888;
+  margin: 0.75rem 0 0;
+  max-width: 280px;
+  line-height: 1.4;
+}
+
 .error {
   color: #e74c3c;
   font-size: 0.85rem;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4,9 +4,11 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: 100vh;
+  height: 100vh;
   text-align: center;
   padding: 2rem;
+  overflow: hidden;
+  box-sizing: border-box;
 }
 
 /* App layout — full viewport, no scroll on outer container */

--- a/frontend/src/components/GuidedTour.tsx
+++ b/frontend/src/components/GuidedTour.tsx
@@ -1,0 +1,63 @@
+import { Joyride, STATUS, type EventData } from "react-joyride";
+import { markTourComplete } from "../utils/tour";
+
+const steps = [
+  {
+    target: '[data-tour="vibe-panel"]',
+    content: "This is your vibe profile. Select genre nodes (last.fm tags) for music that you'd like to hear, or search for specific genres in the search bar. Related genres will appear as you click!",
+    skipBeacon: true,
+    placement: "left" as const,
+  },
+  {
+    target: '[data-tour="venue-map"]',
+    content: "Venues will be color coded by how well the music they typically play matches the vibe you're building on the right. Click a marker for details and to see upcoming shows.",
+    skipBeacon: true,
+    placement: "right" as const,
+  },
+  {
+    target: '[data-tour="sync-vibe"]',
+    content: "Click here to pull your music taste from Spotify and auto-populate a vibe based on your last 6 months of played songs.",
+    skipBeacon: true,
+    placement: "bottom" as const,
+  },
+  {
+    target: '[data-tour="match-slider"]',
+    content: "Drag this slider to only show venues above a certain match percentage.",
+    skipBeacon: true,
+    placement: "bottom" as const,
+  },
+];
+
+interface GuidedTourProps {
+  run: boolean;
+  onFinish: () => void;
+}
+
+export default function GuidedTour({ run, onFinish }: GuidedTourProps) {
+  const handleEvent = (data: EventData) => {
+    if (data.status === STATUS.FINISHED || data.status === STATUS.SKIPPED) {
+      markTourComplete();
+      onFinish();
+    }
+  };
+
+  return (
+    <Joyride
+      steps={steps}
+      run={run}
+      continuous
+      locale={{ last: "Done" }}
+      onEvent={handleEvent}
+      options={{
+        backgroundColor: "#1a1a1a",
+        textColor: "#fff",
+        primaryColor: "#1db954",
+        arrowColor: "#1a1a1a",
+        overlayColor: "rgba(0, 0, 0, 0.6)",
+        zIndex: 100,
+        showProgress: true,
+        buttons: ["back", "skip", "primary"],
+      }}
+    />
+  );
+}

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -12,6 +12,7 @@ interface TopBarProps {
   onSyncVenues?: () => void;
   onSyncVenueVibes?: () => void;
   onLogout?: () => void;
+  onStartTour?: () => void;
 }
 
 export default function TopBar({
@@ -28,13 +29,24 @@ export default function TopBar({
   onSyncVenues,
   onSyncVenueVibes,
   onLogout,
+  onStartTour,
 }: TopBarProps) {
   if (anonymous) {
     return (
       <div className="top-bar">
         <span className="top-bar-greeting">Vibe Seeker</span>
         <div className="top-bar-actions">
-          <a href="/api/auth/login" className="button">
+          {onStartTour && (
+            <button
+              className="tour-help-btn"
+              onClick={onStartTour}
+              title="Show tutorial"
+              aria-label="Show tutorial"
+            >
+              ?
+            </button>
+          )}
+          <a href="/api/auth/login" className="button" title="Spotify login is currently limited to approved accounts" data-tour="sync-vibe">
             Connect Spotify
           </a>
         </div>
@@ -46,7 +58,17 @@ export default function TopBar({
     <div className="top-bar">
       <span className="top-bar-greeting">Hello, {displayName}</span>
       <div className="top-bar-actions">
-        <button className="button" onClick={onSyncVibe} disabled={syncing}>
+        {onStartTour && (
+          <button
+            className="tour-help-btn"
+            onClick={onStartTour}
+            title="Show tutorial"
+            aria-label="Show tutorial"
+          >
+            ?
+          </button>
+        )}
+        <button className="button" onClick={onSyncVibe} disabled={syncing} data-tour="sync-vibe">
           {syncing ? "Syncing..." : "Sync Vibe"}
         </button>
         {vibeError && <span className="error">{vibeError}</span>}

--- a/frontend/src/components/VenueMap.tsx
+++ b/frontend/src/components/VenueMap.tsx
@@ -33,9 +33,9 @@ export default function VenueMap({
   onMinMatchChange,
 }: VenueMapProps) {
   return (
-    <div className="map-area">
+    <div className="map-area" data-tour="venue-map">
       <div className="map-controls">
-        <label className="match-slider-label">
+        <label className="match-slider-label" data-tour="match-slider">
           Min match: {Math.round(minMatch * 100)}%
           <input
             type="range"

--- a/frontend/src/pages/Explore.test.tsx
+++ b/frontend/src/pages/Explore.test.tsx
@@ -95,11 +95,11 @@ describe("Explore", () => {
     renderExplore();
     await waitFor(
       () => {
-        expect(screen.getByText("rock")).toBeInTheDocument();
+        expect(screen.getAllByText("rock").length).toBeGreaterThan(0);
       },
       { timeout: 3000 },
     );
-    expect(screen.getByText("indie")).toBeInTheDocument();
+    expect(screen.getAllByText("indie").length).toBeGreaterThan(0);
   });
 
   it("shows captcha screen when not authenticated", async () => {

--- a/frontend/src/pages/Explore.tsx
+++ b/frontend/src/pages/Explore.tsx
@@ -1,8 +1,11 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback } from "react";
 import { useAuthContext } from "../contexts/AuthContext";
 import TopBar from "../components/TopBar";
 import VenueMap from "../components/VenueMap";
 import VibeGraph from "../components/VibeGraph";
+import VibeSidebar from "../components/VibeSidebar";
+import GuidedTour from "../components/GuidedTour";
+import { shouldAutoStartTour, resetTourComplete } from "../utils/tour";
 import { useVibeGraph } from "../hooks/useVibeGraph";
 import { useVenueMatching } from "../hooks/useVenueMatching";
 import { useVenues } from "../hooks/useVenues";
@@ -13,6 +16,17 @@ export default function Explore() {
   const auth = useAuthContext();
   const [selectedVenue, setSelectedVenue] = useState<VenueData | null>(null);
   const [minMatch, setMinMatch] = useState(0);
+  const [viewMode, setViewMode] = useState<"graph" | "list">("graph");
+  const [tourRunning, setTourRunning] = useState(shouldAutoStartTour);
+
+  const handleStartTour = useCallback(() => {
+    resetTourComplete();
+    setTourRunning(true);
+  }, []);
+
+  const handleTourFinish = useCallback(() => {
+    setTourRunning(false);
+  }, []);
 
   const turnstile = useTurnstile({
     enabled: !auth.authenticated && !auth.loading,
@@ -55,7 +69,8 @@ export default function Explore() {
 
   return (
     <div className="app-layout">
-      <TopBar anonymous />
+      <GuidedTour run={tourRunning} onFinish={handleTourFinish} />
+      <TopBar anonymous onStartTour={handleStartTour} />
       <div className="main-content">
         <VenueMap
           venues={visibleVenues}
@@ -67,18 +82,58 @@ export default function Explore() {
           onClosePopup={() => setSelectedVenue(null)}
           onMinMatchChange={setMinMatch}
         />
-        <VibeGraph
-          nodes={graph.nodes}
-          edges={graph.edges}
-          newNodeIds={graph.newNodeIds}
-          selectedCount={graph.selectedTags.size}
-          totalCount={graph.nodes.length}
-          onToggleNode={graph.toggleNode}
-          onAddNode={graph.addNode}
-          onReset={graph.reset}
-          onSelectAll={graph.selectAll}
-          onSelectNone={graph.selectNone}
-        />
+        <div className="vibe-panel" data-tour="vibe-panel">
+          <div className="vibe-view-toggle">
+            <button
+              className={`vibe-toggle-btn ${viewMode === "graph" ? "active" : ""}`}
+              onClick={() => setViewMode("graph")}
+              title="Graph view"
+              aria-label="Graph view"
+            >
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                <circle cx="4" cy="4" r="2" fill="currentColor" />
+                <circle cx="12" cy="4" r="2" fill="currentColor" />
+                <circle cx="8" cy="12" r="2" fill="currentColor" />
+                <line x1="4" y1="4" x2="12" y2="4" stroke="currentColor" strokeWidth="1" />
+                <line x1="4" y1="4" x2="8" y2="12" stroke="currentColor" strokeWidth="1" />
+                <line x1="12" y1="4" x2="8" y2="12" stroke="currentColor" strokeWidth="1" />
+              </svg>
+            </button>
+            <button
+              className={`vibe-toggle-btn ${viewMode === "list" ? "active" : ""}`}
+              onClick={() => setViewMode("list")}
+              title="List view"
+              aria-label="List view"
+            >
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                <rect x="1" y="2" width="14" height="2" rx="1" fill="currentColor" />
+                <rect x="1" y="7" width="10" height="2" rx="1" fill="currentColor" />
+                <rect x="1" y="12" width="12" height="2" rx="1" fill="currentColor" />
+              </svg>
+            </button>
+          </div>
+          <VibeGraph
+            nodes={graph.nodes}
+            edges={graph.edges}
+            newNodeIds={graph.newNodeIds}
+            selectedCount={graph.selectedTags.size}
+            totalCount={graph.nodes.length}
+            onToggleNode={graph.toggleNode}
+            onAddNode={graph.addNode}
+            onReset={graph.reset}
+            onSelectAll={graph.selectAll}
+            onSelectNone={graph.selectNone}
+          />
+          <div className={`vibe-list-overlay ${viewMode === "list" ? "open" : ""}`} aria-hidden={viewMode !== "list"}>
+            <VibeSidebar
+              genres={vibesFromGraph}
+              selectedGenres={graph.selectedTags}
+              onToggleGenre={graph.toggleNode}
+              onSelectAll={graph.selectAll}
+              onSelectNone={graph.selectNone}
+            />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/Explore.tsx
+++ b/frontend/src/pages/Explore.tsx
@@ -124,7 +124,7 @@ export default function Explore() {
             onSelectAll={graph.selectAll}
             onSelectNone={graph.selectNone}
           />
-          <div className={`vibe-list-overlay ${viewMode === "list" ? "open" : ""}`} aria-hidden={viewMode !== "list"}>
+          <div className={`vibe-list-overlay ${viewMode === "list" ? "open" : ""}`} aria-hidden={viewMode !== "list"} inert={viewMode !== "list" ? true : undefined}>
             <VibeSidebar
               genres={vibesFromGraph}
               selectedGenres={graph.selectedTags}

--- a/frontend/src/pages/Home.test.tsx
+++ b/frontend/src/pages/Home.test.tsx
@@ -156,12 +156,12 @@ describe("Home", () => {
     // Graph renders node labels as SVG text; d3-force simulation may take a tick.
     await waitFor(
       () => {
-        expect(screen.getByText("rock")).toBeInTheDocument();
+        expect(screen.getAllByText("rock").length).toBeGreaterThan(0);
       },
       { timeout: 3000 },
     );
-    expect(screen.getByText("indie")).toBeInTheDocument();
-    expect(screen.getByText("dream pop")).toBeInTheDocument();
+    expect(screen.getAllByText("indie").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("dream pop").length).toBeGreaterThan(0);
   });
 
   it("calls sync endpoint and refreshes vibes on click", async () => {
@@ -194,7 +194,7 @@ describe("Home", () => {
 
     await waitFor(
       () => {
-        expect(screen.getByText("rock")).toBeInTheDocument();
+        expect(screen.getAllByText("rock").length).toBeGreaterThan(0);
       },
       { timeout: 3000 },
     );

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,8 +1,11 @@
-import { useState } from "react";
+import { useState, useMemo, useCallback } from "react";
 import { useAuthContext } from "../contexts/AuthContext";
 import TopBar from "../components/TopBar";
 import VenueMap from "../components/VenueMap";
 import VibeGraph from "../components/VibeGraph";
+import VibeSidebar from "../components/VibeSidebar";
+import GuidedTour from "../components/GuidedTour";
+import { shouldAutoStartTour, resetTourComplete } from "../utils/tour";
 import type { VenueData } from "../types";
 import { useVibeGraph } from "../hooks/useVibeGraph";
 import { useVenueMatching } from "../hooks/useVenueMatching";
@@ -14,6 +17,17 @@ export default function Home() {
   const auth = useAuthContext();
   const [selectedVenue, setSelectedVenue] = useState<VenueData | null>(null);
   const [minMatch, setMinMatch] = useState(0);
+  const [viewMode, setViewMode] = useState<"graph" | "list">("graph");
+  const [tourRunning, setTourRunning] = useState(shouldAutoStartTour);
+
+  const handleStartTour = useCallback(() => {
+    resetTourComplete();
+    setTourRunning(true);
+  }, []);
+
+  const handleTourFinish = useCallback(() => {
+    setTourRunning(false);
+  }, []);
 
   const vibes = useVibes(auth.authenticated);
   const venues = useVenues(auth.authenticated);
@@ -33,6 +47,14 @@ export default function Home() {
     minMatch,
   );
 
+  const vibeGenres = useMemo(() => {
+    const genres: Record<string, number> = {};
+    for (const node of graph.nodes) {
+      genres[node.id] = node.prevalence;
+    }
+    return Object.keys(genres).length > 0 ? genres : null;
+  }, [graph.nodes]);
+
   const vibeSync = useSyncAction<{ vibe_count: number }>(
     "/api/vibe/sync",
     { errorMessage: "Failed to sync vibe from Spotify.", refetch: vibes.refetch },
@@ -50,6 +72,7 @@ export default function Home() {
 
   return (
     <div className="app-layout">
+      <GuidedTour run={tourRunning} onFinish={handleTourFinish} />
       <TopBar
         displayName={auth.user?.display_name || ""}
         syncing={vibeSync.syncing}
@@ -63,6 +86,7 @@ export default function Home() {
         onSyncVenues={venueSync.execute}
         onSyncVenueVibes={venueVibeSync.execute}
         onLogout={auth.logout}
+        onStartTour={handleStartTour}
       />
       <div className="main-content">
         <VenueMap
@@ -75,18 +99,58 @@ export default function Home() {
           onClosePopup={() => setSelectedVenue(null)}
           onMinMatchChange={setMinMatch}
         />
-        <VibeGraph
-          nodes={graph.nodes}
-          edges={graph.edges}
-          newNodeIds={graph.newNodeIds}
-          selectedCount={graph.selectedTags.size}
-          totalCount={graph.nodes.length}
-          onToggleNode={graph.toggleNode}
-          onAddNode={graph.addNode}
-          onReset={graph.reset}
-          onSelectAll={graph.selectAll}
-          onSelectNone={graph.selectNone}
-        />
+        <div className="vibe-panel" data-tour="vibe-panel">
+          <div className="vibe-view-toggle">
+            <button
+              className={`vibe-toggle-btn ${viewMode === "graph" ? "active" : ""}`}
+              onClick={() => setViewMode("graph")}
+              title="Graph view"
+              aria-label="Graph view"
+            >
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                <circle cx="4" cy="4" r="2" fill="currentColor" />
+                <circle cx="12" cy="4" r="2" fill="currentColor" />
+                <circle cx="8" cy="12" r="2" fill="currentColor" />
+                <line x1="4" y1="4" x2="12" y2="4" stroke="currentColor" strokeWidth="1" />
+                <line x1="4" y1="4" x2="8" y2="12" stroke="currentColor" strokeWidth="1" />
+                <line x1="12" y1="4" x2="8" y2="12" stroke="currentColor" strokeWidth="1" />
+              </svg>
+            </button>
+            <button
+              className={`vibe-toggle-btn ${viewMode === "list" ? "active" : ""}`}
+              onClick={() => setViewMode("list")}
+              title="List view"
+              aria-label="List view"
+            >
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                <rect x="1" y="2" width="14" height="2" rx="1" fill="currentColor" />
+                <rect x="1" y="7" width="10" height="2" rx="1" fill="currentColor" />
+                <rect x="1" y="12" width="12" height="2" rx="1" fill="currentColor" />
+              </svg>
+            </button>
+          </div>
+          <VibeGraph
+            nodes={graph.nodes}
+            edges={graph.edges}
+            newNodeIds={graph.newNodeIds}
+            selectedCount={graph.selectedTags.size}
+            totalCount={graph.nodes.length}
+            onToggleNode={graph.toggleNode}
+            onAddNode={graph.addNode}
+            onReset={graph.reset}
+            onSelectAll={graph.selectAll}
+            onSelectNone={graph.selectNone}
+          />
+          <div className={`vibe-list-overlay ${viewMode === "list" ? "open" : ""}`} aria-hidden={viewMode !== "list"}>
+            <VibeSidebar
+              genres={vibeGenres}
+              selectedGenres={graph.selectedTags}
+              onToggleGenre={graph.toggleNode}
+              onSelectAll={graph.selectAll}
+              onSelectNone={graph.selectNone}
+            />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -48,12 +48,13 @@ export default function Home() {
   );
 
   const vibeGenres = useMemo(() => {
+    if (viewMode !== "list") return null;
     const genres: Record<string, number> = {};
     for (const node of graph.nodes) {
       genres[node.id] = node.prevalence;
     }
     return Object.keys(genres).length > 0 ? genres : null;
-  }, [graph.nodes]);
+  }, [graph.nodes, viewMode]);
 
   const vibeSync = useSyncAction<{ vibe_count: number }>(
     "/api/vibe/sync",
@@ -141,7 +142,7 @@ export default function Home() {
             onSelectAll={graph.selectAll}
             onSelectNone={graph.selectNone}
           />
-          <div className={`vibe-list-overlay ${viewMode === "list" ? "open" : ""}`} aria-hidden={viewMode !== "list"}>
+          <div className={`vibe-list-overlay ${viewMode === "list" ? "open" : ""}`} aria-hidden={viewMode !== "list"} inert={viewMode !== "list" ? true : undefined}>
             <VibeSidebar
               genres={vibeGenres}
               selectedGenres={graph.selectedTags}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -12,6 +12,10 @@ export default function Login() {
       <a href="/api/auth/login" className="button">
         Log in with Spotify
       </a>
+      <p className="login-disclaimer">
+        Spotify login is currently limited to approved accounts.
+        If you have to ask, you're probably not on the list — sorry!
+      </p>
       <Link to="/explore" className="button button-secondary" style={{ marginTop: "0.75rem" }}>
         Explore without login
       </Link>

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -8,6 +8,10 @@ vi.stubEnv("VITE_SHOW_SYNC_CONTROLS", "true");
 
 vi.mock("react-map-gl/maplibre", () => import("./__mocks__/react-map-gl-maplibre"));
 vi.mock("maplibre-gl/dist/maplibre-gl.css", () => ({}));
+vi.mock("react-joyride", () => ({
+  Joyride: () => null,
+  STATUS: { FINISHED: "finished", SKIPPED: "skipped" },
+}));
 
 // ResizeObserver is not available in jsdom.
 if (typeof globalThis.ResizeObserver === "undefined") {

--- a/frontend/src/utils/tour.ts
+++ b/frontend/src/utils/tour.ts
@@ -1,0 +1,13 @@
+const TOUR_COMPLETE_KEY = "vibe-seeker-tour-complete";
+
+export function shouldAutoStartTour(): boolean {
+  return !localStorage.getItem(TOUR_COMPLETE_KEY);
+}
+
+export function markTourComplete() {
+  localStorage.setItem(TOUR_COMPLETE_KEY, "true");
+}
+
+export function resetTourComplete() {
+  localStorage.removeItem(TOUR_COMPLETE_KEY);
+}

--- a/frontend/src/utils/tour.ts
+++ b/frontend/src/utils/tour.ts
@@ -1,13 +1,25 @@
 const TOUR_COMPLETE_KEY = "vibe-seeker-tour-complete";
 
 export function shouldAutoStartTour(): boolean {
-  return !localStorage.getItem(TOUR_COMPLETE_KEY);
+  try {
+    return !localStorage.getItem(TOUR_COMPLETE_KEY);
+  } catch {
+    return false;
+  }
 }
 
 export function markTourComplete() {
-  localStorage.setItem(TOUR_COMPLETE_KEY, "true");
+  try {
+    localStorage.setItem(TOUR_COMPLETE_KEY, "true");
+  } catch {
+    // Storage unavailable (e.g. private browsing) — tour will re-show next visit.
+  }
 }
 
 export function resetTourComplete() {
-  localStorage.removeItem(TOUR_COMPLETE_KEY);
+  try {
+    localStorage.removeItem(TOUR_COMPLETE_KEY);
+  } catch {
+    // Storage unavailable.
+  }
 }


### PR DESCRIPTION
## Summary
- **Landing page scroll fix**: Change `.page` from `min-height` to `height: 100vh` with `box-sizing: border-box` and `overflow-y: auto`
- **Spotify login disclaimer**: Casual note below login button explaining access is limited to approved accounts
- **Graph/table view toggle**: Slide-in overlay reusing VibeSidebar bar-chart component with CSS transition, toggle buttons in the vibe panel header
- **Guided tour (react-joyride)**: 4-step walkthrough auto-starts on first visit, persisted in localStorage, replayable via `?` button in top bar
- **Docs**: Fix learnings.md code examples (crypto.subtle.digest, truncated hash, ambiguous path)
- **Deps**: bump actions/setup-node v4→v6, actions/github-script v7→v9

## Test plan
- [ ] Landing page does not scroll on desktop; content scrollable if viewport is very small
- [ ] Disclaimer text visible below Spotify login button
- [ ] Toggle between graph/list views with slide animation on both `/home` and `/explore`
- [ ] Tour auto-starts on first visit, completes with "Done", does not restart on refresh
- [ ] `?` button replays tour
- [ ] `just ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)